### PR TITLE
Add sentry-raven gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,3 +63,5 @@ gem 'devise'
 gem 'devise_cas_authenticatable'
 
 gem 'react-rails'
+
+gem 'sentry-raven'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,8 @@ GEM
     factory_bot_rails (5.1.1)
       factory_bot (~> 5.1.0)
       railties (>= 4.2.0)
+    faraday (0.17.0)
+      multipart-post (>= 1.2, < 3)
     ffi (1.11.1)
     formatador (0.2.5)
     globalid (0.4.2)
@@ -145,6 +147,7 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.12.2)
     msgpack (1.3.1)
+    multipart-post (2.1.1)
     nenv (0.3.0)
     nio4r (2.5.2)
     nokogiri (1.10.4)
@@ -245,6 +248,8 @@ GEM
     selenium-webdriver (3.142.6)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    sentry-raven (2.12.2)
+      faraday (>= 0.7.6, < 1.0)
     shellany (0.0.1)
     shoulda-matchers (4.1.2)
       activesupport (>= 4.2.0)
@@ -319,6 +324,7 @@ DEPENDENCIES
   rspec-rails (~> 3.6)
   sass-rails (~> 5)
   selenium-webdriver
+  sentry-raven
   shoulda-matchers
   spring
   spring-watcher-listen (~> 2.0.0)


### PR DESCRIPTION
Task: https://app.asana.com/0/1136372351092870/1142999165564244

It only needs the `SENTRY_DSN` env variable set in Heroku. No other config/code changes.