### PR TITLE
Adds RubyCAS Core Gem and Setup for External Communication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,12 @@ RUN apk add --update --no-cache \
     imagemagick \
     nodejs \
     yarn \
-    tzdata \
-    git
+    tzdata 
 
 COPY Gemfile* /usr/src/app/
 COPY package.json /usr/src/app/
 COPY yarn.lock /usr/src/app/
+COPY vendor/ /usr/src/app/vendor/
 WORKDIR /usr/src/app
 
 ENV BUNDLE_PATH /gems

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,12 @@ RUN apk add --update --no-cache \
     imagemagick \
     nodejs \
     yarn \
-    tzdata 
+    tzdata \
+    git 
 
 COPY Gemfile* /usr/src/app/
 COPY package.json /usr/src/app/
 COPY yarn.lock /usr/src/app/
-COPY vendor/ /usr/src/app/vendor/
 WORKDIR /usr/src/app
 
 ENV BUNDLE_PATH /gems

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ RUN apk add --update --no-cache \
     imagemagick \
     nodejs \
     yarn \
-    tzdata
+    tzdata \
+    git
 
 COPY Gemfile* /usr/src/app/
 COPY package.json /usr/src/app/

--- a/Gemfile
+++ b/Gemfile
@@ -66,5 +66,6 @@ gem 'react-rails'
 
 gem 'sentry-raven'
 
-gem 'rubycas-server-core', path: '/usr/src/app/vendor/rubycas-server-core'
+# Using a branch for a time being to remove R18n until we decide what we want to do
+gem 'rubycas-server-core', github: 'bebraven/rubycas-server-core', branch: 'platform-compat'
 gem 'rubycas-server-activerecord'

--- a/Gemfile
+++ b/Gemfile
@@ -63,3 +63,6 @@ gem 'devise'
 gem 'devise_cas_authenticatable'
 
 gem 'react-rails'
+
+gem 'rubycas-server-core', git: 'https://github.com/vasilakisfil/rubycas-server-core'
+gem 'rubycas-server-activerecord'

--- a/Gemfile
+++ b/Gemfile
@@ -66,5 +66,5 @@ gem 'react-rails'
 
 gem 'sentry-raven'
 
-gem 'rubycas-server-core', git: 'https://github.com/vasilakisfil/rubycas-server-core'
+gem 'rubycas-server-core', path: '/usr/src/app/vendor/rubycas-server-core'
 gem 'rubycas-server-activerecord'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/vasilakisfil/rubycas-server-core
+  revision: dfc94f4f55e055d969a6fce599bf48099a4a2589
+  specs:
+    rubycas-server-core (0.2.1)
+      activesupport (>= 3.0)
+      r18n-core (~> 2.0.3)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -161,6 +169,7 @@ GEM
       method_source (~> 0.9.0)
     public_suffix (4.0.1)
     puma (3.12.1)
+    r18n-core (2.0.4)
     rack (2.0.7)
     rack-proxy (0.6.5)
       rack
@@ -230,6 +239,8 @@ GEM
     ruby_dep (1.5.0)
     rubycas-client (2.3.9)
       activesupport
+    rubycas-server-activerecord (0.0.3)
+      activerecord
     rubyzip (2.0.0)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
@@ -317,6 +328,8 @@ DEPENDENCIES
   rails (~> 6.0.0)
   react-rails
   rspec-rails (~> 3.6)
+  rubycas-server-activerecord
+  rubycas-server-core!
   sass-rails (~> 5)
   selenium-webdriver
   shoulda-matchers

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,7 @@
-PATH
-  remote: vendor/rubycas-server-core
+GIT
+  remote: https://github.com/bebraven/rubycas-server-core.git
+  revision: 650af2bc7d0368dd3b37da5168b1fc7e23eb03b2
+  branch: platform-compat
   specs:
     rubycas-server-core (0.2.1)
       activesupport (>= 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,8 @@
-GIT
-  remote: https://github.com/vasilakisfil/rubycas-server-core
-  revision: dfc94f4f55e055d969a6fce599bf48099a4a2589
+PATH
+  remote: vendor/rubycas-server-core
   specs:
     rubycas-server-core (0.2.1)
       activesupport (>= 3.0)
-      r18n-core (~> 2.0.3)
 
 GEM
   remote: https://rubygems.org/
@@ -172,7 +170,6 @@ GEM
       method_source (~> 0.9.0)
     public_suffix (4.0.1)
     puma (3.12.1)
-    r18n-core (2.0.4)
     rack (2.0.7)
     rack-proxy (0.6.5)
       rack

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,4 +59,6 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.hosts << "platformweb"
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -60,5 +60,9 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
+  # Host Authorization was introduced in Rails 6 to prevent against DNS.
+  # 0.0.0.0 and localhost are permitted, but we aren't using those to 
+  # communicate across containers. This line allows connection via the
+  # specified name.
   config.hosts << "platformweb"
 end


### PR DESCRIPTION
**Ticket(s)**:
https://app.asana.com/0/1133543009734854/1146936250326599

**Description**:
Breaking out development pieces so it can be merged in. This PR sets up platform to have the RubyCAS Core Server gem and enable communicating with the other boxes in the Braven Dev Network via the `platformweb`.

I also have a PR open on the nginx repo to add the route to the current set up.
https://github.com/beyond-z/nginx-dev/pull/1

**Summary**
- Adds Git to Platform dockerfile
  - This is necessary for bundle to install the RubyCAS Core gem
from GitHub
- Adds RubyCAS Core Gem
- Whitelists `platformweb` so other containers can communicate
  - This is necessary so that other containers to communicate
with the platform box using platformweb:3020
