### PR TITLE
First Round Tests and Refactors for CAS Login

### DIFF
--- a/app/controllers/cas_controller.rb
+++ b/app/controllers/cas_controller.rb
@@ -163,7 +163,6 @@ class CasController < ApplicationController
         logger.info("Credentials for username '#{@username}' successfully validated using #{successful_authenticator.class.name}.")
         logger.debug("Authenticator provided additional user attributes: #{extra_attributes.inspect}") unless extra_attributes.blank?
 
-        # 3.6 (ticket-granting cookie)
         tgt = generate_ticket_granting_ticket(@username, extra_attributes)
         response.set_cookie('tgt', tgt.to_s)
 
@@ -190,15 +189,17 @@ class CasController < ApplicationController
         end
       else
         logger.warn("Invalid credentials given for user '#{@username}'")
-        @message = {:type => 'mistake', :message => "Incorrect username or password."}
-        render :json => @message, status: :unauthorized
+        @message = {
+          :type => 'mistake', :message => "Incorrect username or password."
+        }
+        return render :login, status: :unauthorized
       end
     rescue RubyCAS::Server::Core::AuthenticatorError => e
       logger.error(e)
       # generate another login ticket to allow for re-submitting the form
       @lt = LT.generate_login_ticket(c).ticket
       @message = {:type => 'mistake', :message => e.to_s}
-      render :json => @message, status: :unauthorized
+      return render :login , status: :unauthorized
     end
 
     render :login

--- a/app/controllers/cas_controller.rb
+++ b/app/controllers/cas_controller.rb
@@ -122,7 +122,8 @@ class CasController < ApplicationController
     # generate another login ticket to allow for re-submitting the form after a post
     @lt = LT.generate_login_ticket(c).ticket
 
-    logger.debug("Logging in with username: #{@username}, lt: #{@lt}, service: #{@service}, auth: #{settings.auth.inspect}")
+    settings = RubyCAS::Server::Core::Settings._settings
+    logger.debug("Logging in with username: #{@username}, lt: #{@lt}, service: #{@service}, auth: #{settings.inspect}")
 
     credentials_are_valid = false
     extra_attributes = {}
@@ -188,7 +189,7 @@ class CasController < ApplicationController
         @message = {:type => 'mistake', :message => "Incorrect username or password."}
         render :json => @message, status: :unauthorized
       end
-    rescue Core::Authenticator::AuthenticatorError => e
+    rescue RubyCAS::Server::Core::AuthenticatorError => e
       logger.error(e)
       # generate another login ticket to allow for re-submitting the form
       c = request.env['HTTP_X_FORWARDED_FOR'] || request.env['REMOTE_HOST'] || request.env['REMOTE_ADDR']

--- a/app/controllers/cas_controller.rb
+++ b/app/controllers/cas_controller.rb
@@ -130,10 +130,10 @@ class CasController < ApplicationController
     successful_authenticator = nil
     begin
       auth_index = 0
-      settings.auth.each do |auth_class|
+      settings[:auth].each do |auth_class|
         auth = auth_class.new
 
-        auth_config = settings.config[:authenticator][auth_index]
+        auth_config = settings[:authenticator]
         # pass the authenticator index to the configuration hash in case the authenticator needs to know
         # it splace in the authenticator queue
         auth.configure(auth_config.merge('auth_index' => auth_index))

--- a/app/views/cas/_login_form.erb
+++ b/app/views/cas/_login_form.erb
@@ -25,7 +25,7 @@
       <br />
       <input type="hidden" id="lt" name="lt" value="<%= @lt %>" />
       <input type="hidden" id="service" name="service" value="<%= @service %>" />
-      <div><input class="button-primary" name="commit" type="submit" value="Log in" /></div>
+      <div><input id="login-submit" class="button-primary" name="commit" type="submit" value="Log in" /></div>
       <div id="infoline">
         <%= @infoline %>
       </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,7 +10,6 @@ module Platform
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
-    config.logger = Logger.new(STDOUT)
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -68,4 +68,7 @@ Rails.application.configure do
 
   # Add Rack::LiveReload to the bottom of the middleware stack with the default options:
   config.middleware.insert_after ActionDispatch::Static, Rack::LiveReload
+
+  config.logger = Logger.new(STDOUT)
+
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -70,5 +70,4 @@ Rails.application.configure do
   config.middleware.insert_after ActionDispatch::Static, Rack::LiveReload
 
   config.logger = Logger.new(STDOUT)
-
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,4 +45,5 @@ Rails.application.configure do
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
+  config.logger = Logger.new(STDOUT)
 end

--- a/config/initializers/rubycas_server_core.rb
+++ b/config/initializers/rubycas_server_core.rb
@@ -1,2 +1,37 @@
-cas_config = YAML.load_file("#{Rails.root.to_s}/config/rubycas.yml")[Rails.env]
+cas_config = YAML.load_file("#{Rails.root.to_s}/config/rubycas.yml")[Rails.env].with_indifferent_access
 RubyCAS::Server::Core::setup(cas_config)
+
+auth = []
+
+begin
+  # attempt to instantiate the authenticator
+  cas_config[:authenticator] = [cas_config[:authenticator]] unless cas_config[:authenticator].instance_of? Array
+  cas_config[:authenticator].each { |authenticator| auth << authenticator[:class].constantize}
+rescue NameError
+  if cas_config[:authenticator].instance_of? Array
+    cas_config[:authenticator].each do |authenticator|
+      if !authenticator[:source].nil?
+        # cas_config.yml explicitly names source file
+        require authenticator[:source]
+      end
+      auth << authenticator[:class].constantize
+    end
+  else
+    if cas_config[:authenticator][:source]
+      # cas_config.yml explicitly names source file
+      require cas_config[:authenticator][:source]
+    end
+
+    auth << cas_config[:authenticator][:class].constantize
+    cas_config[:authenticator] = [cas_config[:authenticator]]
+  end
+end
+
+auth.zip(cas_config[:authenticator]).each_with_index{ |auth_conf, index|
+  authenticator, conf = auth_conf
+  $LOG.debug "About to setup #{authenticator} with #{conf.inspect}..."
+  authenticator.setup(conf.merge('auth_index' => index)) if authenticator.respond_to?(:setup)
+  $LOG.debug "Done setting up #{authenticator}."
+}
+
+RubyCAS::Server::Core::Settings._settings[:auth] = auth

--- a/config/rubycas.yml
+++ b/config/rubycas.yml
@@ -8,6 +8,7 @@ default: &default
   log:
     output: log/casserver.log
     level: INFO
+  public_site_domain: join.bebraven.org
   database: &default_db
     database: platform
     reconnect: true

--- a/config/rubycas.yml
+++ b/config/rubycas.yml
@@ -11,6 +11,9 @@ default: &default
 
 development:
   <<: *default
+  log:
+    output: 
+    level: DEBUG
   public_site_domain: joinweb
   cookie_domain: .localhost # this should be the *top* domain - so even for staging, it should be .join.bebraven.org stilldefault_service: http://canvasweb/login/cas
   theme: simple

--- a/config/rubycas.yml
+++ b/config/rubycas.yml
@@ -27,3 +27,44 @@ development:
     host: <%= ENV['DATABASE_HOST'] %>
     username: <%= ENV['DATABASE_USERNAME'] %>
     password: <%= ENV['DATABASE_PASSWORD'] %>
+  authenticator:
+    class: BeyondZ::CustomAuthenticator
+    source: beyondz.rb
+    # NOTE: in the local development environment, expose the Join server to this rubycas app by adding `127.0.0.1   joinweb` to your /etc/hosts file
+    server: joinweb
+    # We can override ssl, port, and self signed options for dev
+    # The default is to use SSL.
+    ssl: false
+    port: 3001
+    allow_self_signed: true
+
+
+test:
+  <<: *default
+  log:
+    output: 
+    level: DEBUG
+  public_site_domain: joinweb
+  cookie_domain: .localhost # this should be the *top* domain - so even for staging, it should be .join.bebraven.org stilldefault_service: http://canvasweb/login/cas
+  theme: simple
+  organization: Braven Docker SSO
+  infoline: Powered by <a href="http://rubycas.github.com">RubyCAS-Server</a>
+  database:
+    database: platform_development
+    reconnect: true
+    adapter: postgresql
+    encoding: unicode
+    host: <%= ENV['DATABASE_HOST'] %>
+    username: <%= ENV['DATABASE_USERNAME'] %>
+    password: <%= ENV['DATABASE_PASSWORD'] %>
+  authenticator:
+    class: BeyondZ::CustomAuthenticator
+    source: beyondz.rb
+    # NOTE: in the local development environment, expose the Join server to this rubycas app by adding `127.0.0.1   joinweb` to your /etc/hosts file
+    server: joinweb
+    # We can override ssl, port, and self signed options for dev
+    # The default is to use SSL.
+    ssl: false
+    port: 3001
+    allow_self_signed: true
+

--- a/config/rubycas.yml
+++ b/config/rubycas.yml
@@ -1,5 +1,6 @@
 
 default: &default
+  infoline: Powered by <a href="http://rubycas.github.com">RubyCAS-Server-Core</a>
   log:
     output: log/casserver.log
     level: INFO
@@ -15,10 +16,10 @@ development:
     output: 
     level: DEBUG
   public_site_domain: joinweb
-  cookie_domain: .localhost # this should be the *top* domain - so even for staging, it should be .join.bebraven.org stilldefault_service: http://canvasweb/login/cas
+  # this should be the *top* domain - so even for staging, it should be .join.bebraven.org stilldefault_service: http://canvasweb/login/cas
+  cookie_domain: .localhost 
   theme: simple
   organization: Braven Docker SSO
-  infoline: Powered by <a href="http://rubycas.github.com">RubyCAS-Server</a>
   database:
     database: platform_development
     reconnect: true
@@ -45,12 +46,13 @@ test:
     output: 
     level: DEBUG
   public_site_domain: joinweb
-  cookie_domain: .localhost # this should be the *top* domain - so even for staging, it should be .join.bebraven.org stilldefault_service: http://canvasweb/login/cas
+  # this should be the *top* domain - so even for staging, it should be .join.bebraven.org stilldefault_service: http://canvasweb/login/cas
+  cookie_domain: .localhost 
+  organization: "RSPEC-TEST"
+  infoline: "This is an rspec test."  
   theme: simple
-  organization: Braven Docker SSO
-  infoline: Powered by <a href="http://rubycas.github.com">RubyCAS-Server</a>
   database:
-    database: platform_development
+    database: platform_test
     reconnect: true
     adapter: postgresql
     encoding: unicode
@@ -67,4 +69,8 @@ test:
     ssl: false
     port: 3001
     allow_self_signed: true
-
+  uri_path: /test
+  disable_auto_migrations: true
+  quiet: true
+  default_locale: en
+  enable_single_sign_out: true

--- a/config/rubycas.yml
+++ b/config/rubycas.yml
@@ -8,7 +8,23 @@ default: &default
   maximum_unused_service_ticket_lifetime: 300
   maximum_session_lifetime: 172800
   maximum_remember_me_lifetime: 604800
-  
+  database: &default_db
+    database: platform
+    reconnect: true
+    adapter: postgresql
+    encoding: unicode
+    host: <%= ENV['DATABASE_HOST'] %>
+    username: <%= ENV['DATABASE_USERNAME'] %>
+    password: <%= ENV['DATABASE_PASSWORD'] %>
+  authenticator: &default_bz_auth
+    class: BeyondZ::CustomAuthenticator
+    source: beyondz.rb
+    server: join.bebraven.org
+    # We can override ssl, port, and self signed options for dev
+    # The default is to use SSL.
+    # ssl: false
+    # port: 3001
+    # allow_self_signed: true
 
 development:
   <<: *default
@@ -21,24 +37,11 @@ development:
   theme: simple
   organization: Braven Docker SSO
   database:
+    <<: *default_db
     database: platform_development
-    reconnect: true
-    adapter: postgresql
-    encoding: unicode
-    host: <%= ENV['DATABASE_HOST'] %>
-    username: <%= ENV['DATABASE_USERNAME'] %>
-    password: <%= ENV['DATABASE_PASSWORD'] %>
   authenticator:
-    class: BeyondZ::CustomAuthenticator
-    source: beyondz.rb
-    # NOTE: in the local development environment, expose the Join server to this rubycas app by adding `127.0.0.1   joinweb` to your /etc/hosts file
+    <<: *default_bz_auth
     server: joinweb
-    # We can override ssl, port, and self signed options for dev
-    # The default is to use SSL.
-    ssl: false
-    port: 3001
-    allow_self_signed: true
-
 
 test:
   <<: *default
@@ -52,23 +55,11 @@ test:
   infoline: "This is an rspec test."  
   theme: simple
   database:
+    <<: *default_db
     database: platform_test
-    reconnect: true
-    adapter: postgresql
-    encoding: unicode
-    host: <%= ENV['DATABASE_HOST'] %>
-    username: <%= ENV['DATABASE_USERNAME'] %>
-    password: <%= ENV['DATABASE_PASSWORD'] %>
   authenticator:
-    class: BeyondZ::CustomAuthenticator
-    source: beyondz.rb
-    # NOTE: in the local development environment, expose the Join server to this rubycas app by adding `127.0.0.1   joinweb` to your /etc/hosts file
+    <<: *default_bz_auth
     server: joinweb
-    # We can override ssl, port, and self signed options for dev
-    # The default is to use SSL.
-    ssl: false
-    port: 3001
-    allow_self_signed: true
   uri_path: /test
   disable_auto_migrations: true
   quiet: true

--- a/config/rubycas.yml
+++ b/config/rubycas.yml
@@ -1,13 +1,13 @@
 
 default: &default
-  infoline: Powered by <a href="http://rubycas.github.com">RubyCAS-Server-Core</a>
-  log:
-    output: log/casserver.log
-    level: INFO
   maximum_unused_login_ticket_lifetime: 300
   maximum_unused_service_ticket_lifetime: 300
   maximum_session_lifetime: 172800
   maximum_remember_me_lifetime: 604800
+  infoline: Powered by <a href="http://rubycas.github.com">RubyCAS-Server-Core</a>
+  log:
+    output: log/casserver.log
+    level: INFO
   database: &default_db
     database: platform
     reconnect: true
@@ -42,6 +42,9 @@ development:
   authenticator:
     <<: *default_bz_auth
     server: joinweb
+    ssl: false
+    port: 3001
+    allow_self_signed: true
 
 test:
   <<: *default
@@ -60,8 +63,13 @@ test:
   authenticator:
     <<: *default_bz_auth
     server: joinweb
+    ssl: false
+    port: 3001
+    allow_self_signed: true
   uri_path: /test
   disable_auto_migrations: true
   quiet: true
   default_locale: en
   enable_single_sign_out: true
+
+  

--- a/db/migrate/20191030035633_initial_rubycas_tables.rb
+++ b/db/migrate/20191030035633_initial_rubycas_tables.rb
@@ -16,8 +16,8 @@ class InitialRubycasTables < ActiveRecord::Migration[6.0]
       t.column :consumed,   :datetime, :null => true
       t.column :client_hostname, :string, :null => false
       t.column :username,   :string,  :null => false
-      t.column :type,       :string,   :null => false
       t.column :proxy_granting_ticket_id, :integer, :null => true
+      t.column :ticket_granting_ticket_id, :integer, :null => true
     end
 
     create_table :ticket_granting_tickets, :force => true do |t|
@@ -26,6 +26,9 @@ class InitialRubycasTables < ActiveRecord::Migration[6.0]
       t.column :created_at, :timestamp, :null => false
       t.column :client_hostname, :string, :null => false
       t.column :username,   :string,    :null => false
+      t.column :remember_me,   :string,    :null => false
+      t.column :extra_attributes, :null => false
+
     end
 
     create_table :proxy_granting_tickets, :force => true do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -177,15 +177,17 @@ ActiveRecord::Schema.define(version: 2019_11_04_193832) do
     t.datetime "consumed"
     t.string "client_hostname", null: false
     t.string "username", null: false
-    t.string "type", null: false
     t.integer "proxy_granting_ticket_id"
-  end
+    t.integer "ticket_granting_ticket_id"
+end
 
   create_table "ticket_granting_tickets", force: :cascade do |t|
     t.string "ticket", null: false
     t.datetime "created_at", null: false
     t.string "client_hostname", null: false
     t.string "username", null: false
+    t.string "remember_me", null: false
+    t.string "extra_attributes", null: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/lib/beyondz.rb
+++ b/lib/beyondz.rb
@@ -24,7 +24,6 @@ module BeyondZ
         'password' => credentials[:password]
       )
       response = http.request(request)
-
       return (response.body == "true")
     end
   end

--- a/lib/beyondz.rb
+++ b/lib/beyondz.rb
@@ -1,0 +1,31 @@
+module BeyondZ
+  class CustomAuthenticator < RubyCAS::Server::Core::Authenticator
+    def self.setup(options)
+      raise RubyCAS::Server::Core::AuthenticatorError, "Authenticator configuration needs server" unless options[:server]
+
+      @@server = options[:server]
+      @@ssl = (!options[:ssl].nil?) ? options[:ssl] : true
+      @@port = (!options[:port].nil?) ? options[:port] : (@@ssl ? 443 : 80)
+      @@allow_self_signed = (!options[:allow_self_signed].nil?) ? options[:allow_self_signed] : false
+    end
+
+    def validate(credentials)
+      http = Net::HTTP.new(@@server, @@port)
+      if @@ssl
+        http.use_ssl = true
+        if @@allow_self_signed
+          http.verify_mode = OpenSSL::SSL::VERIFY_NONE # self-signed cert would fail
+        end
+      end
+
+      request = Net::HTTP::Post.new('/users/check_credentials')
+      request.set_form_data(
+        'username' => credentials[:username],
+        'password' => credentials[:password]
+      )
+      response = http.request(request)
+
+      return (response.body == "true")
+    end
+  end
+end

--- a/spec/capybara_helper.rb
+++ b/spec/capybara_helper.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include Capybara::DSL
+end

--- a/spec/routing/cas/login_spec.rb
+++ b/spec/routing/cas/login_spec.rb
@@ -4,6 +4,9 @@ require "capybara_helper"
 VALID_USERNAME = 'platform_user'
 VALID_PASSWORD = 'rspec_test'
 
+INVALID_USERNAME = 'bad_user'
+INVALID_PASSWORD = 'bad_pass'
+
 RSpec.describe CasController, type: :routing do
   describe 'RubyCAS routing' do
     describe "/login" do
@@ -22,6 +25,23 @@ RSpec.describe CasController, type: :routing do
 
         # Ensure that the login was successful
         expect(page).to have_content("You have successfully logged in")
+      end
+
+      it "fails to log in with bad credentials" do
+        # Go to log in page to sigin in
+        visit "/login"
+
+        # Input login credentials
+        fill_in 'username', :with => INVALID_USERNAME
+        fill_in 'password', :with => INVALID_PASSWORD
+        
+        # Make sure there is a login button that can be clicked
+        # Capybara with Selenium can have problems with javascript
+        expect(page).to have_button('login-submit', disabled: false)
+        click_button 'login-submit'
+
+        # Ensure that the login was successful
+        expect(page).to have_content("Incorrect username or password")
       end
     end
   end

--- a/spec/routing/cas/login_spec.rb
+++ b/spec/routing/cas/login_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+require "capybara_helper"
+
+VALID_USERNAME = 'platform_user'
+VALID_PASSWORD = 'rspec_test'
+
+RSpec.describe CasController, type: :routing do
+  describe 'RubyCAS routing' do
+    describe "/login" do
+      it "logs in successfully without a service url" do
+        # Go to log in page to sigin in
+        visit "/login"
+
+        # Input login credentials
+        fill_in 'username', :with => VALID_USERNAME
+        fill_in 'password', :with => VALID_PASSWORD
+        
+        # Make sure there is a login button that can be clicked
+        # Capybara with Selenium can have problems with javascript
+        expect(page).to have_button('login-submit', disabled: false)
+        click_button 'login-submit'
+
+        # Ensure that the login was successful
+        expect(page).to have_content("You have successfully logged in")
+      end
+    end
+  end
+end

--- a/spec/routing/cas/login_spec.rb
+++ b/spec/routing/cas/login_spec.rb
@@ -97,6 +97,20 @@ RSpec.describe CasController, type: :routing do
         # New ticket should be generated
         expect(current_url).not_to include(@params["ticket"])
       end
+
+      it "logs in successfully using onlyLoginForm parameter" do
+        # Goto form only version of login page
+        visit "/login?onlyLoginForm=true"
+
+        fill_in "username", :with => VALID_USERNAME
+        fill_in "password", :with => VALID_PASSWORD
+
+        expect(page).to have_button("login-submit", disabled: false)
+        click_button "login-submit"
+
+        # Ensure that the login was successful
+        expect(page).to have_content("You have successfully logged in")
+      end
     end
   end
 end

--- a/spec/routing/cas/login_spec.rb
+++ b/spec/routing/cas/login_spec.rb
@@ -1,11 +1,17 @@
 require "rails_helper"
 require "capybara_helper"
+require "erb"
+
+include ERB::Util
+
 
 VALID_USERNAME = 'platform_user'
 VALID_PASSWORD = 'rspec_test'
 
 INVALID_USERNAME = 'bad_user'
 INVALID_PASSWORD = 'bad_pass'
+
+RETURN_SERVICE = "http://braven"
 
 RSpec.describe CasController, type: :routing do
   describe 'RubyCAS routing' do
@@ -40,8 +46,33 @@ RSpec.describe CasController, type: :routing do
         expect(page).to have_button('login-submit', disabled: false)
         click_button 'login-submit'
 
-        # Ensure that the login was successful
+        # Ensure that the login was failed
         expect(page).to have_content("Incorrect username or password")
+      end
+      
+      it "fails to log in without input" do
+        visit "/login"
+        
+        click_button 'login-submit'
+
+        expect(page).to have_content("Incorrect username or password")
+      end
+
+      it "logs in successfully and redirects to service url" do
+        # Go to log in page to sigin in
+        visit "/login?service=#{url_encode(RETURN_SERVICE)}"
+
+        # Input login credentials
+        fill_in 'username', :with => VALID_USERNAME
+        fill_in 'password', :with => VALID_PASSWORD
+        
+        # Make sure there is a login button that can be clicked
+        # Capybara with Selenium can have problems with javascript
+        expect(page).to have_button('login-submit', disabled: false)
+        click_button 'login-submit'
+
+        # Ensure that the login was successful
+        expect(current_url).to match(RETURN_SERVICE)
       end
     end
   end

--- a/spec/routing/cas/login_spec.rb
+++ b/spec/routing/cas/login_spec.rb
@@ -1,33 +1,33 @@
 require "rails_helper"
 require "capybara_helper"
-require "erb"
 
 include ERB::Util
+include Rack::Utils
 
 
-VALID_USERNAME = 'platform_user'
-VALID_PASSWORD = 'rspec_test'
+VALID_USERNAME = "platform_user"
+VALID_PASSWORD = "rspec_test"
 
-INVALID_USERNAME = 'bad_user'
-INVALID_PASSWORD = 'bad_pass'
+INVALID_USERNAME = "bad_user"
+INVALID_PASSWORD = "bad_pass"
 
-RETURN_SERVICE = "http://braven"
+RETURN_SERVICE = "http://braven/"
 
 RSpec.describe CasController, type: :routing do
-  describe 'RubyCAS routing' do
+  describe "RubyCAS routing" do
     describe "/login" do
       it "logs in successfully without a service url" do
         # Go to log in page to sigin in
         visit "/login"
 
         # Input login credentials
-        fill_in 'username', :with => VALID_USERNAME
-        fill_in 'password', :with => VALID_PASSWORD
+        fill_in "username", :with => VALID_USERNAME
+        fill_in "password", :with => VALID_PASSWORD
         
         # Make sure there is a login button that can be clicked
         # Capybara with Selenium can have problems with javascript
-        expect(page).to have_button('login-submit', disabled: false)
-        click_button 'login-submit'
+        expect(page).to have_button("login-submit", disabled: false)
+        click_button "login-submit"
 
         # Ensure that the login was successful
         expect(page).to have_content("You have successfully logged in")
@@ -38,13 +38,13 @@ RSpec.describe CasController, type: :routing do
         visit "/login"
 
         # Input login credentials
-        fill_in 'username', :with => INVALID_USERNAME
-        fill_in 'password', :with => INVALID_PASSWORD
+        fill_in "username", :with => INVALID_USERNAME
+        fill_in "password", :with => INVALID_PASSWORD
         
         # Make sure there is a login button that can be clicked
         # Capybara with Selenium can have problems with javascript
-        expect(page).to have_button('login-submit', disabled: false)
-        click_button 'login-submit'
+        expect(page).to have_button("login-submit", disabled: false)
+        click_button "login-submit"
 
         # Ensure that the login was failed
         expect(page).to have_content("Incorrect username or password")
@@ -53,7 +53,7 @@ RSpec.describe CasController, type: :routing do
       it "fails to log in without input" do
         visit "/login"
         
-        click_button 'login-submit'
+        click_button "login-submit"
 
         expect(page).to have_content("Incorrect username or password")
       end
@@ -63,16 +63,39 @@ RSpec.describe CasController, type: :routing do
         visit "/login?service=#{url_encode(RETURN_SERVICE)}"
 
         # Input login credentials
-        fill_in 'username', :with => VALID_USERNAME
-        fill_in 'password', :with => VALID_PASSWORD
+        fill_in "username", :with => VALID_USERNAME
+        fill_in "password", :with => VALID_PASSWORD
         
         # Make sure there is a login button that can be clicked
         # Capybara with Selenium can have problems with javascript
-        expect(page).to have_button('login-submit', disabled: false)
-        click_button 'login-submit'
+        expect(page).to have_button("login-submit", disabled: false)
+        click_button "login-submit"
 
         # Ensure that the login was successful
-        expect(current_url).to match(RETURN_SERVICE)
+        expect(current_url).to include(RETURN_SERVICE)
+        expect(current_url).to include("ticket")
+      end
+
+      it "validates existing tickets and generates new one" do
+        visit "/login?service=#{url_encode(RETURN_SERVICE)}"
+        expect(page).to have_button("login-submit", disabled: false)
+
+        fill_in "username", :with => VALID_USERNAME
+        fill_in "password", :with => VALID_PASSWORD
+        click_button "login-submit"
+
+        expect(current_url).to include(RETURN_SERVICE)
+        expect(current_url).to include("ticket")
+
+        # Get current ticket to check against next generated ticket
+        @params = parse_query(current_url, "&?,")
+        expect(@params).to include("ticket")
+
+        # Revisit login page to validate current ticket
+        visit "/login?service=#{url_encode(RETURN_SERVICE)}"
+
+        # New ticket should be generated
+        expect(current_url).not_to include(@params["ticket"])
       end
     end
   end


### PR DESCRIPTION
**Ticket(s)**:
https://app.asana.com/0/1133543009734854/1150084536382593/f

**Description**:
This is the first round of tests and refactors to the login route. Now that I have been exposed to Rails and done some reading, I understand what needs to be done. This adds environment application configs, adds missing db columns for RubyCAS Core ActiveRecord gem, cleans up Double Render errors, removes invalid code, and some styling changes. 

**Summary**:
- Adds environment based configs for RubyCAS YML
- Updates migration schema
- Refactors some logic from the original brought over code
- Brings over BeyondZ authenticator since we will be using the system for a bit
- Removes code that is not longer valid in the transfer Sinatra to Rails
- Adds tests for `/login`