### PR TITLE
Updates to Honeycomb Installation 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,9 +47,9 @@ group :development do
   gem 'guard-bundler', require: false
   gem 'guard-yarn', require: false
   gem 'guard-migrate', require: false
-  gem 'pry-rescue'
-  gem 'pry-stack_explorer'
-  gem 'rubocop'
+  gem 'pry-rescue', require: false
+  gem 'pry-stack_explorer', require: false
+  gem 'rubocop', require: false
 end
 
 group :test do
@@ -65,7 +65,7 @@ group :test do
   gem 'codacy-coverage'
 
   # Clean database after tests
-  gem 'database_cleaner'
+  gem 'database_cleaner', require: false
 
   # Stores mocks in reusable file
   gem 'vcr'
@@ -92,4 +92,4 @@ gem 'rubycas-server-core', github: 'bebraven/rubycas-server-core', branch: 'plat
 gem 'rubycas-server-activerecord'
 
 # Honeycomb
-gem 'honeycomb-beeline'
+gem 'honeycomb-beeline', require: false

--- a/config/initializers/honeycomb.rb
+++ b/config/initializers/honeycomb.rb
@@ -1,11 +1,13 @@
-if Gem.loaded_specs.has_key?('honeycomb-beeline')
-  Rails.logger.info "Honeycomb detected. Initalizing setup."
-  require "honeycomb-beeline"
+if Rails.application.secrets.honeycomb_write_key && Rails.application.secrets.honeycomb_dataset
+  if Gem.loaded_specs.has_key?('honeycomb-beeline')
+    require "honeycomb-beeline"
 
-  Honeycomb.configure do |config|
-    config.write_key = Rails.application.secrets.honeycomb_write_key
-    config.dataset = Rails.application.secrets.honeycomb_dataset
+    Rails.logger.info "Honeycomb Beeline detected. Initalizing setup."
+    Honeycomb.configure do |config|
+      config.write_key = Rails.application.secrets.honeycomb_write_key
+      config.dataset = Rails.application.secrets.honeycomb_dataset
+    end
+  else
+    Rails.logger.warn "Honeycomb Beeline is not install. Skipping initialization."
   end
-else
-  Rails.logger.warn "Honeycomb is not install. Skipping initialization."
 end

--- a/config/initializers/honeycomb.rb
+++ b/config/initializers/honeycomb.rb
@@ -1,6 +1,6 @@
 require "honeycomb-beeline"
 
 Honeycomb.configure do |config|
-  config.write_key = Rails.application.secrets.honeycomb_api_key
+  config.write_key = Rails.application.secrets.honeycomb_write_key
   config.dataset = Rails.application.secrets.honeycomb_dataset
 end

--- a/config/initializers/honeycomb.rb
+++ b/config/initializers/honeycomb.rb
@@ -1,3 +1,5 @@
+require "honeycomb-beeline"
+
 Honeycomb.configure do |config|
   config.write_key = Rails.application.secrets.honeycomb_api_key
   config.dataset = Rails.application.secrets.honeycomb_dataset

--- a/config/initializers/honeycomb.rb
+++ b/config/initializers/honeycomb.rb
@@ -1,6 +1,11 @@
-require "honeycomb-beeline"
+if Gem.loaded_specs.has_key?('honeycomb-beeline')
+  Rails.logger.info "Honeycomb detected. Initalizing setup."
+  require "honeycomb-beeline"
 
-Honeycomb.configure do |config|
-  config.write_key = Rails.application.secrets.honeycomb_write_key
-  config.dataset = Rails.application.secrets.honeycomb_dataset
+  Honeycomb.configure do |config|
+    config.write_key = Rails.application.secrets.honeycomb_write_key
+    config.dataset = Rails.application.secrets.honeycomb_dataset
+  end
+else
+  Rails.logger.warn "Honeycomb is not install. Skipping initialization."
 end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -7,7 +7,7 @@ development:
   devise_secret_key: <%= ENV['DEVISE_SECRET_KEY'] %>
   devise_pepper: <%= ENV['DEVISE_PEPPER'] %>
   honeycomb_dataset: <%= ENV['HONEYCOMB_DATASET'] %>
-  honeycomb_api_key: <%= ENV['HONEYCOMB_API_KEY'] %>
+  honeycomb_write_key: <%= ENV['HONEYCOMB_WRITE_KEY'] %>
 
 test:
   database_host: <%= ENV['DATABASE_HOST'] %>
@@ -18,7 +18,7 @@ test:
   devise_secret_key: <%= ENV['DEVISE_SECRET_KEY'] %>
   devise_pepper: <%= ENV['DEVISE_PEPPER'] %>
   honeycomb_dataset: <%= ENV['HONEYCOMB_DATASET'] %>
-  honeycomb_api_key: <%= ENV['HONEYCOMB_API_KEY'] %>
+  honeycomb_write_key: <%= ENV['HONEYCOMB_WRITE_KEY'] %>
 
 staging:
   database_host: <%= ENV['DATABASE_HOST'] %>
@@ -29,7 +29,7 @@ staging:
   devise_secret_key: <%= ENV['DEVISE_SECRET_KEY'] %>
   devise_pepper: <%= ENV['DEVISE_PEPPER'] %>
   honeycomb_dataset: <%= ENV['HONEYCOMB_DATASET'] %>
-  honeycomb_api_key: <%= ENV['HONEYCOMB_API_KEY'] %>
+  honeycomb_write_key: <%= ENV['HONEYCOMB_WRITE_KEY'] %>
 
 production:
   database_host: <%= ENV['DATABASE_HOST'] %>
@@ -40,4 +40,4 @@ production:
   devise_secret_key: <%= ENV['DEVISE_SECRET_KEY'] %>
   devise_pepper: <%= ENV['DEVISE_PEPPER'] %>
   honeycomb_dataset: <%= ENV['HONEYCOMB_DATASET'] %>
-  honeycomb_api_key: <%= ENV['HONEYCOMB_API_KEY'] %>
+  honeycomb_write_key: <%= ENV['HONEYCOMB_WRITE_KEY'] %>


### PR DESCRIPTION
**Ticket(s)**:
https://app.asana.com/0/1133543009734854/1153847903754889/f

**Summary**:
- Adds `require=false` for Gems that are not needed to run the application
- Wraps initialization in check to see if gem is present
- Updates  `HONEYCOMB_API_KEY` to `HONEYCOMB_WRITE_KEY`
  - This is so Honeycomb Drain can be used in the future