### PR TITLE
Use window.prompt for 'modal' input

### DIFF
--- a/app/controllers/course_contents_controller.rb
+++ b/app/controllers/course_contents_controller.rb
@@ -14,11 +14,13 @@ class CourseContentsController < ApplicationController
 
   # GET /course_contents/new
   def new
+    @course_contents = CourseContent.all
     @course_content = CourseContent.new
   end
 
   # GET /course_contents/1/edit
   def edit
+    @course_contents = CourseContent.all
   end
 
   # POST /course_contents

--- a/app/javascript/components/ContentEditor.js
+++ b/app/javascript/components/ContentEditor.js
@@ -422,13 +422,25 @@ class ContentEditor extends Component {
                                             key="imageUpload"
                                             enabled={this.state.enabledCommands.includes('imageUpload')}
                                             onClick={this.showFileUpload}
-                                            {...{name: 'Image', id: uuidv4()}}
+                                            {...{name: 'Image (Upload)', id: uuidv4()}}
+                                        />
+                                        <ContentPartPreview
+                                            key="imageInsert"
+                                            enabled={this.state.enabledCommands.includes('imageInsert')}
+                                            onClick={( id ) => {
+                                                const url = window.prompt('URL', 'http://placekitten.com/200/300');
+                                                this.editor.execute( 'imageInsert', {source: url} );
+                                                this.editor.editing.view.focus();
+                                            }}
+                                            {...{name: 'Image (URL)', id: uuidv4()}}
                                         />
                                         <ContentPartPreview
                                             key="insertTableContent"
                                             enabled={this.state.enabledCommands.includes('insertTableContent')}
                                             onClick={( id ) => {
-                                                this.editor.execute( 'insertTableContent', id , {rows: 2, columns: 2});
+                                                const rows = window.prompt('How many rows?', 2);
+                                                const columns = window.prompt('How many columns?', 2);
+                                                this.editor.execute( 'insertTableContent', id , {rows: rows, columns: columns});
                                                 this.editor.editing.view.focus();
                                             }}
                                             {...{name: 'Table', id: uuidv4()}}
@@ -446,7 +458,8 @@ class ContentEditor extends Component {
                                             key="insertIFrameContent"
                                             enabled={this.state.enabledCommands.includes('insertIFrameContent')}
                                             onClick={( id ) => {
-                                                this.editor.execute( 'insertIFrameContent', id, 'http://example.com' );
+                                                const url = window.prompt('URL', 'http://example.com' );
+                                                this.editor.execute( 'insertIFrameContent', id, url );
                                                 this.editor.editing.view.focus();
                                             }}
                                             {...{name: 'iFrame', id: uuidv4()}}
@@ -455,7 +468,8 @@ class ContentEditor extends Component {
                                             key="insertVideoContent"
                                             enabled={this.state.enabledCommands.includes('insertVideoContent')}
                                             onClick={( id ) => {
-                                                this.editor.execute( 'insertVideoContent', id, 'https://www.youtube.com/embed/yyRrKMb8oIg?rel=0' );
+                                                const url = window.prompt('URL', 'https://www.youtube.com/embed/yyRrKMb8oIg?rel=0' );
+                                                this.editor.execute( 'insertVideoContent', id, url );
                                                 this.editor.editing.view.focus();
                                             }}
                                             {...{name: 'Video', id: uuidv4()}}


### PR DESCRIPTION
An ugly, but quick workaround for "modal" inputs in the editor UI.

When you click on the buttons in the right sidebar in the editor, some of them need a way to input different options before inserting a component. E.g. we use this to set the height/width of tables, set the URL to use for iframes/videos/images, etc.

Example workflow:

1. Click the "IFrame" button to insert an iframe
2. You get a popup asking for a URL
3. The popup returns the URL you enter to the JS and stores it in a variable
4. We pass the URL variable into the 'insertIFrame' command, so it knows what URL to use
5. A frame with your custom URL is inserted into the editor

I tried using some actual modal prompt stuff, but I kept hitting dead ends and decided it's more complicated than we have time for. We should get a UX / frontend person to give this a makeover later.

Task: https://app.asana.com/0/1142638035116665/1155859225081638/f