### PR TITLE
Add context-sensitive right toolbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,12 @@ We also have the pry and rescue gems so that you can break and debug code. Here 
 a spec that is throwing an exception.
     bundle exec rescue rspec spec/a_failing_spec.rb --format documentation   
 
+For troubleshooting ckeditor-specific issues in the content editor, append '?debug' to the URL:
+
+    http://platformweb/course_contents/new?debug
+
+That will attach the [CKEditor Inspector](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/development-tools.html#ckeditor-5-inspector).
+
 **TODO:** talk about pry and other dev and troubleshooting techniques.
 
 ### Accessibility testing

--- a/app/assets/stylesheets/course_contents.scss
+++ b/app/assets/stylesheets/course_contents.scss
@@ -3,7 +3,15 @@
 // You can use Sass (SCSS) here: http://sass-lang.com/
 /* assets/styles.css */
 
-/* --- Sidebar styles --- */
+/* --- Right sidebar styles --- */
+ul.widget-list li.disabled,
+ul.widget-list li.disabled:hover {
+  border: 1px solid #bbb;
+  background-color: #ddd;
+  color: #888;
+}
+
+/* --- Left Sidebar styles --- */
 
 /* Position and sizing of burger button */
 .bm-burger-button {

--- a/app/assets/stylesheets/course_contents.scss
+++ b/app/assets/stylesheets/course_contents.scss
@@ -72,6 +72,20 @@ Note: Beware of modifying this element as it can break the animations - you shou
   background: rgba(0, 0, 0, 0.3);
 }
 
+/* --- Content Editor styles ----- */
+section.content-section {
+    border: 1px dashed grey;
+}
+
+div#wysiwyg-container {
+    max-height: 640px;
+    overflow-y: auto;
+}
+
+// overwrite reboot.css
+legend {
+    font-size: 1rem !important;
+}
 
 /* --- General.application styles --------------------------------------------------- */
 

--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -127,7 +127,8 @@ main {
   background: #F3F3F3; }
 
 #toolbar-page-settings,
-#toolbar-components {
+#toolbar-components,
+#toolbar-contextual {
   padding: 1em; }
 
 #workspace {
@@ -135,6 +136,14 @@ main {
 
 #toolbar-components {
   border-top: 1px solid #ccc; }
+
+#toolbar-contextual {
+  border-top: 1px solid #ccc; }
+
+#toolbar-contextual:empty {
+          transform:translate(9999px);
+
+  display: none; }
 
 #workspace {
   border-top: 1px solid #D1D1D1; }

--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -34,26 +34,30 @@ header {
   background: white;
   box-shadow: 0 0 3px #D1D1D1; }
 
-ul#view-mode, header ul, ul#component-types, ul#widget-list, ul#edit-page {
+ul#view-mode, header ul, ul#component-types, ul.widget-list, ul#edit-page {
   list-style: none;
   margin: 0;
   padding: 0;
   overflow: auto; }
 
+ul.widget-list {
+  padding-bottom: 15px;
+}
+
 ul#view-mode {
   margin: 0 0 1px 0; }
 
-ul#widget-list li {
+ul.widget-list li {
   border-radius: 4px;
   border: 1px solid #CCC;
   padding: 0.5em;
   margin-bottom: 0.5em; }
 
-ul#widget-list li:hover {
+ul.widget-list li:hover {
   background: #C4E6E7;
   border-color: #9AD7D7; }
 
-ul#component-types li, ul#widget-list li, ul#view-mode li, ul#edit-page li {
+ul#component-types li, ul.widget-list li, ul#view-mode li, ul#edit-page li {
   display: block; }
 
 ul#component-types li, ul#view-mode li, ul#edit-page li {
@@ -157,12 +161,12 @@ ul#component-types li {
   font-size: 80%;
   background: #F3F3F3; }
 
-ul#widget-list li {
+ul.widget-list li {
   position: relative;
   padding-right: 2.5em;
   border-bottom-width: 2px; }
 
-ul#widget-list li:after {
+ul.widget-list li:after {
   content: "+";
   position: absolute;
   right: 0.5em;
@@ -182,7 +186,7 @@ ul#component-types li:hover, ul#component-types li.active {
   position: relative;
   border-bottom-color: #F3F3F3; }
 
-ul#widget-list li:hover:after {
+ul.widget-list li:hover:after {
   background: #5BBBBA; }
 
 /*# sourceMappingURL=style.css.map */

--- a/app/javascript/ckeditor/contentcommonediting.js
+++ b/app/javascript/ckeditor/contentcommonediting.js
@@ -2,6 +2,7 @@ import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import { enablePlaceholder } from '@ckeditor/ckeditor5-engine/src/view/placeholder';
 import { toWidget, toWidgetEditable } from '@ckeditor/ckeditor5-widget/src/utils';
 import Widget from '@ckeditor/ckeditor5-widget/src/widget';
+import InsertTextInputCommand from './inserttextinputcommand';
 
 export default class ContentCommonEditing extends Plugin {
     static get requires() {
@@ -11,6 +12,8 @@ export default class ContentCommonEditing extends Plugin {
     init() {
         this._defineSchema();
         this._defineConverters();
+
+        this.editor.commands.add( 'insertTextInput', new InsertTextInputCommand( this.editor ) );
     }
 
     _defineSchema() {
@@ -460,7 +463,7 @@ export default class ContentCommonEditing extends Plugin {
             model: ( viewElement, modelWriter ) => {
                 return modelWriter.createElement( 'textInput', {
                     'data-bz-retained': viewElement.getAttribute('data-bz-retained'),
-                    'placeholder': viewElement.getAttribute('placeholder')
+                    'placeholder': viewElement.getAttribute('placeholder') || ''
                 } );
             }
         } );
@@ -470,7 +473,7 @@ export default class ContentCommonEditing extends Plugin {
                 const input = viewWriter.createEmptyElement( 'input', {
                     'type': 'text',
                     'data-bz-retained': modelElement.getAttribute('data-bz-retained'),
-                    'placeholder': modelElement.getAttribute('placeholder')
+                    'placeholder': modelElement.getAttribute('placeholder') || ''
                 } );
                 return input;
             }
@@ -481,7 +484,7 @@ export default class ContentCommonEditing extends Plugin {
                 const input = viewWriter.createEmptyElement( 'input', {
                     'type': 'text',
                     'data-bz-retained': modelElement.getAttribute('data-bz-retained'),
-                    'placeholder': modelElement.getAttribute('placeholder')
+                    'placeholder': modelElement.getAttribute('placeholder') || ''
                 } );
                 return toWidget( input, viewWriter );
             }

--- a/app/javascript/ckeditor/contentcommonediting.js
+++ b/app/javascript/ckeditor/contentcommonediting.js
@@ -495,7 +495,7 @@ export default class ContentCommonEditing extends Plugin {
             model: ( viewElement, modelWriter ) => {
                 return modelWriter.createElement( 'textArea', {
                     'data-bz-retained': viewElement.getAttribute('data-bz-retained'),
-                    'placeholder': viewElement.getAttribute('placeholder')
+                    'placeholder': viewElement.getAttribute('placeholder') || ''
                 } );
             }
         } );
@@ -504,7 +504,7 @@ export default class ContentCommonEditing extends Plugin {
             view: ( modelElement, viewWriter ) => {
                 const textarea = viewWriter.createEmptyElement( 'textarea', {
                     'data-bz-retained': modelElement.getAttribute('data-bz-retained'),
-                    'placeholder': modelElement.getAttribute('placeholder')
+                    'placeholder': modelElement.getAttribute('placeholder') || ''
                 } );
                 return textarea;
             }
@@ -514,7 +514,7 @@ export default class ContentCommonEditing extends Plugin {
             view: ( modelElement, viewWriter ) => {
                 const textarea = viewWriter.createEmptyElement( 'textarea', {
                     'data-bz-retained': modelElement.getAttribute('data-bz-retained'),
-                    'placeholder': modelElement.getAttribute('placeholder')
+                    'placeholder': modelElement.getAttribute('placeholder') || ''
                 } );
                 return toWidget( textarea, viewWriter );
             }
@@ -573,9 +573,9 @@ export default class ContentCommonEditing extends Plugin {
                 return modelWriter.createElement( 'slider', {
                     'class': viewElement.getAttribute('class') || '',
                     'data-bz-retained': viewElement.getAttribute('data-bz-retained'),
-                    'min': viewElement.getAttribute('min'),
-                    'max': viewElement.getAttribute('max'),
-                    'step': viewElement.getAttribute('step') || '',
+                    'min': viewElement.getAttribute('min') || 0,
+                    'max': viewElement.getAttribute('max') || 10,
+                    'step': viewElement.getAttribute('step') || 1,
                 } );
             }
         } );
@@ -586,9 +586,9 @@ export default class ContentCommonEditing extends Plugin {
                     'type': 'range',
                     'class': modelElement.getAttribute('class') || '',
                     'data-bz-retained': modelElement.getAttribute('data-bz-retained'),
-                    'min': modelElement.getAttribute('min'),
-                    'max': modelElement.getAttribute('max'),
-                    'step': modelElement.getAttribute('step') || '',
+                    'min': modelElement.getAttribute('min') || 0,
+                    'max': modelElement.getAttribute('max') || 10, 
+                    'step': modelElement.getAttribute('step') || 1,
                 } );
                 return input;
             }
@@ -600,9 +600,9 @@ export default class ContentCommonEditing extends Plugin {
                     'type': 'range',
                     'class': modelElement.getAttribute('class') || '',
                     'data-bz-retained': modelElement.getAttribute('data-bz-retained'),
-                    'min': modelElement.getAttribute('min'),
-                    'max': modelElement.getAttribute('max'),
-                    'step': modelElement.getAttribute('step') || '',
+                    'min': modelElement.getAttribute('min') || 0,
+                    'max': modelElement.getAttribute('max') || 10,
+                    'step': modelElement.getAttribute('step') || 1,
                 } );
                 return toWidget( input, viewWriter );
             }

--- a/app/javascript/ckeditor/customelementattributepreservation.js
+++ b/app/javascript/ckeditor/customelementattributepreservation.js
@@ -175,7 +175,6 @@ function setupAllowedAttributePreservation( editor ) {
     editor.conversion.for( 'upcast' ).elementToElement( {
         view: 'p',
         model: ( viewElement, modelWriter ) => {
-        console.log(viewElement.getAttributes());
             return modelWriter.createElement( 'paragraph', filterAllowedAttributes( viewElement.getAttributes() ) );
         },
         // Use high priority to overwrite existing paragraph converter.

--- a/app/javascript/ckeditor/insertslidercommand.js
+++ b/app/javascript/ckeditor/insertslidercommand.js
@@ -1,9 +1,9 @@
 import Command from '@ckeditor/ckeditor5-core/src/command';
 
 export default class InsertSliderCommand extends Command {
-    execute( id ) {
+    execute( id, options ) {
         this.editor.model.change( writer => {
-            this.editor.model.insertContent( createSlider( writer, id ) );
+            this.editor.model.insertContent( createSlider( writer, id, options ) );
         } );
     }
 
@@ -16,7 +16,7 @@ export default class InsertSliderCommand extends Command {
     }
 }
 
-function createSlider( writer, id ) {
-    const sliderInput = writer.createElement( 'slider' );
+function createSlider( writer, id, options ) {
+    const sliderInput = writer.createElement( 'slider', options );
     return sliderInput;
 }

--- a/app/javascript/ckeditor/inserttextareacommand.js
+++ b/app/javascript/ckeditor/inserttextareacommand.js
@@ -1,9 +1,11 @@
 import Command from '@ckeditor/ckeditor5-core/src/command';
 
 export default class InsertTextAreaCommand extends Command {
-    execute( id ) {
+    execute( id, placeholder ) {
         this.editor.model.change( writer => {
-            this.editor.model.insertContent( createTextArea( writer, id ) );
+            const textArea = createTextArea( writer, id, placeholder );
+            this.editor.model.insertContent( textArea );
+            writer.setSelection( textArea, 'on' );
         } );
     }
 
@@ -16,7 +18,7 @@ export default class InsertTextAreaCommand extends Command {
     }
 }
 
-function createTextArea( writer, id ) {
-    const textAreaDiv = writer.createElement( 'textArea' );
-    return textAreaDiv;
+function createTextArea( writer, id, placeholder ) {
+    const textArea = writer.createElement( 'textArea', { 'data-bz-retained': id, placeholder: placeholder } );
+    return textArea;
 }

--- a/app/javascript/ckeditor/inserttextinputcommand.js
+++ b/app/javascript/ckeditor/inserttextinputcommand.js
@@ -1,0 +1,24 @@
+import Command from '@ckeditor/ckeditor5-core/src/command';
+
+export default class InsertTextInputCommand extends Command {
+    execute( id, placeholder ) {
+        this.editor.model.change( writer => {
+            const textInput = createTextInput( writer, id, placeholder );
+            this.editor.model.insertContent( textInput );
+            writer.setSelection( textInput, 'on' );
+        } );
+    }
+
+    refresh() {
+        const model = this.editor.model;
+        const selection = model.document.selection;
+        const allowedIn = model.schema.findAllowedParent( selection.getFirstPosition(), 'textInput' );
+
+        this.isEnabled = allowedIn !== null;
+    }
+}
+
+function createTextInput( writer, id, placeholder ) {
+    const textInput = writer.createElement( 'textInput', { 'data-bz-retained': id, placeholder: placeholder } );
+    return textInput;
+}

--- a/app/javascript/ckeditor/sectionediting.js
+++ b/app/javascript/ckeditor/sectionediting.js
@@ -1,4 +1,5 @@
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+import { enablePlaceholder } from '@ckeditor/ckeditor5-engine/src/view/placeholder';
 import { toWidget, toWidgetEditable } from '@ckeditor/ckeditor5-widget/src/utils';
 import Widget from '@ckeditor/ckeditor5-widget/src/widget';
 import InsertSectionCommand from './insertsectioncommand';
@@ -19,8 +20,6 @@ export default class SectionEditing extends Plugin {
         const schema = this.editor.model.schema;
 
         schema.register( 'section', {
-            //isObject: true,
-
             allowIn: '$root',
 
             // Allow content which is allowed in the root (e.g. paragraphs).
@@ -40,6 +39,7 @@ export default class SectionEditing extends Plugin {
     _defineConverters() {
         const editor = this.editor;
         const conversion = editor.conversion;
+        const { editing, data, model } = editor;
 
         // <section> converters
         conversion.for( 'upcast' ).elementToElement( {
@@ -50,15 +50,15 @@ export default class SectionEditing extends Plugin {
             model: ( viewElement, modelWriter ) => {
                 // Read the "data-id" attribute from the view and set it as the "id" in the model.
                 return modelWriter.createElement( 'section', {
-                    id: viewElement.getAttribute( 'data-id' )
+                    'id': viewElement.getAttribute( 'data-id' )
                 } );
             }
         } );
         conversion.for( 'dataDowncast' ).elementToElement( {
             model: 'section',
             view: ( modelElement, viewWriter ) => {
-                return viewWriter.createEditableElement( 'section', {
-                    class: 'content-section',
+                return viewWriter.createContainerElement( 'section', {
+                    'class': 'content-section',
                     'data-id': modelElement.getAttribute( 'id' )
                 } );
             }
@@ -66,14 +66,18 @@ export default class SectionEditing extends Plugin {
         conversion.for( 'editingDowncast' ).elementToElement( {
             model: 'section',
             view: ( modelElement, viewWriter ) => {
-                const id = modelElement.getAttribute( 'id' );
-
                 const section = viewWriter.createContainerElement( 'section', {
-                    class: 'content-section',
-                    'data-id': id
+                    'class': 'content-section',
+                    'data-id': modelElement.getAttribute( 'id' )
                 } );
 
-                // Note: sections are not converted into widgets! They're just an element.
+                enablePlaceholder( {
+                    view: editing.view,
+                    element: section,
+                    text: '[Empty section]',
+                    isDirectHost: false
+                } );
+
                 return section;
             }
         } );

--- a/app/javascript/components/ContentEditor.js
+++ b/app/javascript/components/ContentEditor.js
@@ -308,7 +308,10 @@ class ContentEditor extends Component {
 
         // CKEditor 5 inspector allows you to take a peek into the editor's model and view
         // data layers. Use it to debug the application and learn more about the editor.
-        CKEditorInspector.attach( editor );
+        // Disable unless debug mode is enabled.
+        if ( window.location.search === '?debug' ) {
+            CKEditorInspector.attach( editor );
+        }
     }
 
     handlePublish( evt ) {

--- a/app/javascript/components/ContentEditor.js
+++ b/app/javascript/components/ContentEditor.js
@@ -375,233 +375,221 @@ class ContentEditor extends Component {
                             <h4>Insert Component</h4>
 
                         </div>
-                        <Tabs>
-                            <TabList id="component-types">
-                                <Tab className="active">Content</Tab>
-                                <Tab>Question</Tab>
-                                <Tab>Library</Tab>
-                            </TabList>
+                        <div id="toolbar-contextual">
+                            {this.state.modelPath.map( modelElement => {
+                                if ( ['textArea', 'textInput'].includes( modelElement ) ) {
+                                    // Text inputs and textareas have placeholder settings.
+                                    return (
+                                        <>
+                                            <h5>Text Input</h5>
+                                            <input
+                                                type='text'
+                                                id='input-placeholder'
+                                                defaultValue={this.state['selectedElement'].getAttribute('placeholder')}
+                                                onChange={( evt ) => {
+                                                    this.editor.execute( 'insertTextArea', 'retained-data-todo', evt.target.value );
+                                                }}
+                                            />
+                                            <label htmlFor='input-placeholder'>Placeholder</label>
+                                        </>
+                                    );
+                                } else if ( 'slider' === modelElement ) {
+                                    // Sliders have several different settings to change.
+                                    const min = this.state['selectedElement'].getAttribute('min');
+                                    const max = this.state['selectedElement'].getAttribute('max');
+                                    const step = this.state['selectedElement'].getAttribute('step');
 
-                            <TabPanel>
-                                <div id="toolbar-contextual">
-                                    {this.state.modelPath.map( modelElement => {
-                                        if ( ['textArea', 'textInput'].includes( modelElement ) ) {
-                                            // Text inputs and textareas have placeholder settings.
-                                            return (
-                                                <>
-                                                    <h5>Text Input</h5>
-                                                    <input
-                                                        type='text'
-                                                        id='input-placeholder'
-                                                        defaultValue={this.state['selectedElement'].getAttribute('placeholder')}
-                                                        onChange={( evt ) => {
-                                                            this.editor.execute( 'insertTextArea', 'retained-data-todo', evt.target.value );
-                                                        }}
-                                                    />
-                                                    <label htmlFor='input-placeholder'>Placeholder</label>
-                                                </>
-                                            );
-                                        } else if ( 'slider' === modelElement ) {
-                                            // Sliders have several different settings to change.
-                                            const min = this.state['selectedElement'].getAttribute('min');
-                                            const max = this.state['selectedElement'].getAttribute('max');
-                                            const step = this.state['selectedElement'].getAttribute('step');
+                                    return (
+                                        <>
+                                            <h5>Slider</h5>
 
-                                            return (
-                                                <>
-                                                    <h5>Slider</h5>
+                                            <input
+                                                type='number'
+                                                id='input-min'
+                                                defaultValue={min}
+                                                onChange={( evt ) => {
+                                                    this.editor.execute( 'insertSlider', 'retained-data-todo', {
+                                                        min: evt.target.value,
+                                                        max: max,
+                                                        step: step,
+                                                    } );
+                                                }}
+                                            />
+                                            <label htmlFor='input-min'>Min</label>
 
-                                                    <input
-                                                        type='number'
-                                                        id='input-min'
-                                                        defaultValue={min}
-                                                        onChange={( evt ) => {
-                                                            this.editor.execute( 'insertSlider', 'retained-data-todo', {
-                                                                min: evt.target.value,
-                                                                max: max,
-                                                                step: step,
-                                                            } );
-                                                        }}
-                                                    />
-                                                    <label htmlFor='input-min'>Min</label>
+                                            <input
+                                                type='number'
+                                                id='input-max'
+                                                defaultValue={max}
+                                                onChange={( evt ) => {
+                                                    this.editor.execute( 'insertSlider', 'retained-data-todo', {
+                                                        min: min,
+                                                        max: evt.target.value,
+                                                        step: step,
+                                                    } );
+                                                }}
+                                            />
+                                            <label htmlFor='input-max'>Max</label>
 
-                                                    <input
-                                                        type='number'
-                                                        id='input-max'
-                                                        defaultValue={max}
-                                                        onChange={( evt ) => {
-                                                            this.editor.execute( 'insertSlider', 'retained-data-todo', {
-                                                                min: min,
-                                                                max: evt.target.value,
-                                                                step: step,
-                                                            } );
-                                                        }}
-                                                    />
-                                                    <label htmlFor='input-max'>Max</label>
-
-                                                    <input
-                                                        type='number'
-                                                        id='input-step'
-                                                        defaultValue={step}
-                                                        onChange={( evt ) => {
-                                                            this.editor.execute( 'insertSlider', 'retained-data-todo', {
-                                                                min: min,
-                                                                max: max,
-                                                                step: evt.target.value,
-                                                            } );
-                                                        }}
-                                                    />
-                                                    <label htmlFor='input-step'>Step</label>
-                                                </>
-                                            );
-                                        }
-                                    } ) }
-                                </div>
-                                <div id="toolbar-components">
-                                    <ul key="content-part-list" id="widget-list">
-                                        <ContentPartPreview
-                                            key="insertSection"
-                                            enabled={this.state.enabledCommands.includes('insertSection')}
-                                            onClick={( id ) => {
-                                                this.editor.execute( 'insertSection', id );
-                                                this.editor.editing.view.focus();
-                                            }}
-                                            {...{name: 'Section', id: uuidv4()}}
-                                        />
-                                        <ContentPartPreview
-                                            key="insertChecklistQuestion"
-                                            enabled={this.state.enabledCommands.includes('insertChecklistQuestion')}
-                                            onClick={( id ) => {
-                                                this.editor.execute( 'insertChecklistQuestion', id );
-                                                this.editor.editing.view.focus();
-                                            }}
-                                            {...{name: 'Checklist Question', id: uuidv4()}}
-                                        />
-                                        <ContentPartPreview
-                                            key="insertRadioQuestion"
-                                            enabled={this.state.enabledCommands.includes('insertRadioQuestion')}
-                                            onClick={( id ) => {
-                                                this.editor.execute( 'insertRadioQuestion', id );
-                                                this.editor.editing.view.focus();
-                                            }}
-                                            {...{name: 'Radio Question', id: uuidv4()}}
-                                        />
-                                        <ContentPartPreview
-                                            key="insertMatchingQuestion"
-                                            enabled={this.state.enabledCommands.includes('insertMatchingQuestion')}
-                                            onClick={( id ) => {
-                                                this.editor.execute( 'insertMatchingQuestion', id );
-                                                this.editor.editing.view.focus();
-                                            }}
-                                            {...{name: 'Matching Question', id: uuidv4()}}
-                                        />
-                                        <ContentPartPreview
-                                            key="insertTextAreaQuestion"
-                                            enabled={this.state.enabledCommands.includes('insertTextAreaQuestion')}
-                                            onClick={( id ) => {
-                                                this.editor.execute( 'insertTextAreaQuestion', id );
-                                                this.editor.editing.view.focus();
-                                            }}
-                                            {...{name: 'Text Area Question', id: uuidv4()}}
-                                        />
-                                        <ContentPartPreview
-                                            key="insertTextArea"
-                                            enabled={this.state.enabledCommands.includes('insertTextArea')}
-                                            onClick={( id ) => {
-                                                this.editor.execute( 'insertTextArea', id );
-                                                this.editor.editing.view.focus();
-                                            }}
-                                            {...{name: 'Text Area', id: uuidv4()}}
-                                        />
-                                        <ContentPartPreview
-                                            key="insertSlider"
-                                            enabled={this.state.enabledCommands.includes('insertSlider')}
-                                            onClick={( id ) => {
-                                                this.editor.execute( 'insertSlider', id );
-                                                this.editor.editing.view.focus();
-                                            }}
-                                            {...{name: 'Slider', id: uuidv4()}}
-                                        />
-                                        <input
-                                            type="file"
-                                            style={{ display: "none" }}
-                                            ref={this.fileUpload}
-                                            onChange={e => {
-                                                this.editor.execute( 'imageUpload', {file: e.target.files[0]} );
-                                                this.editor.editing.view.focus();
-                                            }}
-                                        />
-                                        <ContentPartPreview
-                                            key="imageUpload"
-                                            enabled={this.state.enabledCommands.includes('imageUpload')}
-                                            onClick={this.showFileUpload}
-                                            {...{name: 'Image (Upload)', id: uuidv4()}}
-                                        />
-                                        <ContentPartPreview
-                                            key="imageInsert"
-                                            enabled={this.state.enabledCommands.includes('imageInsert')}
-                                            onClick={( id ) => {
-                                                const url = window.prompt('URL', 'http://placekitten.com/200/300');
-                                                this.editor.execute( 'imageInsert', {source: url} );
-                                                this.editor.editing.view.focus();
-                                            }}
-                                            {...{name: 'Image (URL)', id: uuidv4()}}
-                                        />
-                                        <ContentPartPreview
-                                            key="insertTableContent"
-                                            enabled={this.state.enabledCommands.includes('insertTableContent')}
-                                            onClick={( id ) => {
-                                                const rows = window.prompt('How many rows?', 2);
-                                                const columns = window.prompt('How many columns?', 2);
-                                                this.editor.execute( 'insertTableContent', id , {rows: rows, columns: columns});
-                                                this.editor.editing.view.focus();
-                                            }}
-                                            {...{name: 'Table', id: uuidv4()}}
-                                        />
-                                        <ContentPartPreview
-                                            key="insertBlockquoteContent"
-                                            enabled={this.state.enabledCommands.includes('insertBlockquoteContent')}
-                                            onClick={( id ) => {
-                                                this.editor.execute( 'insertBlockquoteContent', id );
-                                                this.editor.editing.view.focus();
-                                            }}
-                                            {...{name: 'Quote', id: uuidv4()}}
-                                        />
-                                        <ContentPartPreview
-                                            key="insertIFrameContent"
-                                            enabled={this.state.enabledCommands.includes('insertIFrameContent')}
-                                            onClick={( id ) => {
-                                                const url = window.prompt('URL', 'http://example.com' );
-                                                this.editor.execute( 'insertIFrameContent', id, url );
-                                                this.editor.editing.view.focus();
-                                            }}
-                                            {...{name: 'iFrame', id: uuidv4()}}
-                                        />
-                                        <ContentPartPreview
-                                            key="insertVideoContent"
-                                            enabled={this.state.enabledCommands.includes('insertVideoContent')}
-                                            onClick={( id ) => {
-                                                const url = window.prompt('URL', 'https://www.youtube.com/embed/yyRrKMb8oIg?rel=0' );
-                                                this.editor.execute( 'insertVideoContent', id, url );
-                                                this.editor.editing.view.focus();
-                                            }}
-                                            {...{name: 'Video', id: uuidv4()}}
-                                        />
-                                        <ContentPartPreview
-                                            key="insertRateThisModuleQuestion"
-                                            enabled={this.state.enabledCommands.includes('insertRateThisModuleQuestion')}
-                                            onClick={( id ) => {
-                                                this.editor.execute( 'insertRateThisModuleQuestion', id );
-                                                this.editor.editing.view.focus();
-                                            }}
-                                            {...{name: 'Rate This Module', id: uuidv4()}}
-                                        />
-                                    </ul>
-                                </div>
-                            </TabPanel>
-                            <TabPanel>Not Implemented</TabPanel>
-                            <TabPanel>Not Implemented</TabPanel>
-                        </Tabs>
+                                            <input
+                                                type='number'
+                                                id='input-step'
+                                                defaultValue={step}
+                                                onChange={( evt ) => {
+                                                    this.editor.execute( 'insertSlider', 'retained-data-todo', {
+                                                        min: min,
+                                                        max: max,
+                                                        step: evt.target.value,
+                                                    } );
+                                                }}
+                                            />
+                                            <label htmlFor='input-step'>Step</label>
+                                        </>
+                                    );
+                                }
+                            } ) }
+                        </div>
+                        <div id="toolbar-components">
+                            <ul key="content-part-list" id="widget-list">
+                                <ContentPartPreview
+                                    key="insertSection"
+                                    enabled={this.state.enabledCommands.includes('insertSection')}
+                                    onClick={( id ) => {
+                                        this.editor.execute( 'insertSection', id );
+                                        this.editor.editing.view.focus();
+                                    }}
+                                    {...{name: 'Section', id: uuidv4()}}
+                                />
+                                <ContentPartPreview
+                                    key="insertChecklistQuestion"
+                                    enabled={this.state.enabledCommands.includes('insertChecklistQuestion')}
+                                    onClick={( id ) => {
+                                        this.editor.execute( 'insertChecklistQuestion', id );
+                                        this.editor.editing.view.focus();
+                                    }}
+                                    {...{name: 'Checklist Question', id: uuidv4()}}
+                                />
+                                <ContentPartPreview
+                                    key="insertRadioQuestion"
+                                    enabled={this.state.enabledCommands.includes('insertRadioQuestion')}
+                                    onClick={( id ) => {
+                                        this.editor.execute( 'insertRadioQuestion', id );
+                                        this.editor.editing.view.focus();
+                                    }}
+                                    {...{name: 'Radio Question', id: uuidv4()}}
+                                />
+                                <ContentPartPreview
+                                    key="insertMatchingQuestion"
+                                    enabled={this.state.enabledCommands.includes('insertMatchingQuestion')}
+                                    onClick={( id ) => {
+                                        this.editor.execute( 'insertMatchingQuestion', id );
+                                        this.editor.editing.view.focus();
+                                    }}
+                                    {...{name: 'Matching Question', id: uuidv4()}}
+                                />
+                                <ContentPartPreview
+                                    key="insertTextAreaQuestion"
+                                    enabled={this.state.enabledCommands.includes('insertTextAreaQuestion')}
+                                    onClick={( id ) => {
+                                        this.editor.execute( 'insertTextAreaQuestion', id );
+                                        this.editor.editing.view.focus();
+                                    }}
+                                    {...{name: 'Text Area Question', id: uuidv4()}}
+                                />
+                                <ContentPartPreview
+                                    key="insertTextArea"
+                                    enabled={this.state.enabledCommands.includes('insertTextArea')}
+                                    onClick={( id ) => {
+                                        this.editor.execute( 'insertTextArea', id );
+                                        this.editor.editing.view.focus();
+                                    }}
+                                    {...{name: 'Text Area', id: uuidv4()}}
+                                />
+                                <ContentPartPreview
+                                    key="insertSlider"
+                                    enabled={this.state.enabledCommands.includes('insertSlider')}
+                                    onClick={( id ) => {
+                                        this.editor.execute( 'insertSlider', id );
+                                        this.editor.editing.view.focus();
+                                    }}
+                                    {...{name: 'Slider', id: uuidv4()}}
+                                />
+                                <input
+                                    type="file"
+                                    style={{ display: "none" }}
+                                    ref={this.fileUpload}
+                                    onChange={e => {
+                                        this.editor.execute( 'imageUpload', {file: e.target.files[0]} );
+                                        this.editor.editing.view.focus();
+                                    }}
+                                />
+                                <ContentPartPreview
+                                    key="imageUpload"
+                                    enabled={this.state.enabledCommands.includes('imageUpload')}
+                                    onClick={this.showFileUpload}
+                                    {...{name: 'Image (Upload)', id: uuidv4()}}
+                                />
+                                <ContentPartPreview
+                                    key="imageInsert"
+                                    enabled={this.state.enabledCommands.includes('imageInsert')}
+                                    onClick={( id ) => {
+                                        const url = window.prompt('URL', 'http://placekitten.com/200/300');
+                                        this.editor.execute( 'imageInsert', {source: url} );
+                                        this.editor.editing.view.focus();
+                                    }}
+                                    {...{name: 'Image (URL)', id: uuidv4()}}
+                                />
+                                <ContentPartPreview
+                                    key="insertTableContent"
+                                    enabled={this.state.enabledCommands.includes('insertTableContent')}
+                                    onClick={( id ) => {
+                                        const rows = window.prompt('How many rows?', 2);
+                                        const columns = window.prompt('How many columns?', 2);
+                                        this.editor.execute( 'insertTableContent', id , {rows: rows, columns: columns});
+                                        this.editor.editing.view.focus();
+                                    }}
+                                    {...{name: 'Table', id: uuidv4()}}
+                                />
+                                <ContentPartPreview
+                                    key="insertBlockquoteContent"
+                                    enabled={this.state.enabledCommands.includes('insertBlockquoteContent')}
+                                    onClick={( id ) => {
+                                        this.editor.execute( 'insertBlockquoteContent', id );
+                                        this.editor.editing.view.focus();
+                                    }}
+                                    {...{name: 'Quote', id: uuidv4()}}
+                                />
+                                <ContentPartPreview
+                                    key="insertIFrameContent"
+                                    enabled={this.state.enabledCommands.includes('insertIFrameContent')}
+                                    onClick={( id ) => {
+                                        const url = window.prompt('URL', 'http://example.com' );
+                                        this.editor.execute( 'insertIFrameContent', id, url );
+                                        this.editor.editing.view.focus();
+                                    }}
+                                    {...{name: 'iFrame', id: uuidv4()}}
+                                />
+                                <ContentPartPreview
+                                    key="insertVideoContent"
+                                    enabled={this.state.enabledCommands.includes('insertVideoContent')}
+                                    onClick={( id ) => {
+                                        const url = window.prompt('URL', 'https://www.youtube.com/embed/yyRrKMb8oIg?rel=0' );
+                                        this.editor.execute( 'insertVideoContent', id, url );
+                                        this.editor.editing.view.focus();
+                                    }}
+                                    {...{name: 'Video', id: uuidv4()}}
+                                />
+                                <ContentPartPreview
+                                    key="insertRateThisModuleQuestion"
+                                    enabled={this.state.enabledCommands.includes('insertRateThisModuleQuestion')}
+                                    onClick={( id ) => {
+                                        this.editor.execute( 'insertRateThisModuleQuestion', id );
+                                        this.editor.editing.view.focus();
+                                    }}
+                                    {...{name: 'Rate This Module', id: uuidv4()}}
+                                />
+                            </ul>
+                        </div>
                     </div>
                     <Tabs>
                         <div id="workspace">

--- a/app/javascript/components/ContentEditor.js
+++ b/app/javascript/components/ContentEditor.js
@@ -380,6 +380,10 @@ class ContentEditor extends Component {
                             {this.state.modelPath.map( modelElement => {
                                 if ( ['textArea', 'textInput'].includes( modelElement ) ) {
                                     // Text inputs and textareas have placeholder settings.
+                                    const commandMap = {
+                                        'textArea': 'insertTextArea',
+                                        'textInput': 'insertTextInput',
+                                    }
                                     return (
                                         <>
                                             <h4>Text Input</h4>
@@ -388,7 +392,7 @@ class ContentEditor extends Component {
                                                 id='input-placeholder'
                                                 defaultValue={this.state['selectedElement'].getAttribute('placeholder')}
                                                 onChange={( evt ) => {
-                                                    this.editor.execute( 'insertTextArea', 'retained-data-todo', evt.target.value );
+                                                    this.editor.execute( commandMap[modelElement], 'retained-data-todo', evt.target.value );
                                                 }}
                                             />
                                             <label htmlFor='input-placeholder'>Placeholder</label>

--- a/app/javascript/components/ContentEditor.js
+++ b/app/javascript/components/ContentEditor.js
@@ -372,8 +372,6 @@ class ContentEditor extends Component {
                                        placeholder="Page Title"
                                 />
                             </h2>
-                            <h4>Insert Component</h4>
-
                         </div>
                         <div id="toolbar-contextual">
                             {this.state.modelPath.map( modelElement => {
@@ -381,7 +379,7 @@ class ContentEditor extends Component {
                                     // Text inputs and textareas have placeholder settings.
                                     return (
                                         <>
-                                            <h5>Text Input</h5>
+                                            <h4>Text Input</h4>
                                             <input
                                                 type='text'
                                                 id='input-placeholder'
@@ -401,7 +399,7 @@ class ContentEditor extends Component {
 
                                     return (
                                         <>
-                                            <h5>Slider</h5>
+                                            <h4>Slider</h4>
 
                                             <input
                                                 type='number'
@@ -450,6 +448,8 @@ class ContentEditor extends Component {
                             } ) }
                         </div>
                         <div id="toolbar-components">
+                            <h4>Insert Component</h4>
+
                             <ul key="content-part-list" id="widget-list">
                                 <ContentPartPreview
                                     key="insertSection"

--- a/app/javascript/components/ContentEditor.js
+++ b/app/javascript/components/ContentEditor.js
@@ -195,6 +195,7 @@ class ContentEditor extends Component {
             enabledCommands: [],
             modelPath: [],
             viewPath: [],
+            selectedElement: undefined,
         };
 
         // The configuration of the <CKEditor> instance.
@@ -251,7 +252,8 @@ class ContentEditor extends Component {
 
         this.setState( {
             enabledCommands: [...commands.names()].filter( x => commands.get(x).isEnabled ),
-            modelPath: modelAncestorNames.concat(selectedModelElement.name)
+            modelPath: modelAncestorNames.concat(selectedModelElement.name),
+            selectedElement: selectedModelElement
         } );
 
         // The view selection works differently than the model selection, and we can't
@@ -382,9 +384,78 @@ class ContentEditor extends Component {
 
                             <TabPanel>
                                 <div id="toolbar-contextual">
-                                    {this.state.viewPath.join(' > ')}
-                                       <br/>
-                                    {this.state.modelPath.join(' > ')}
+                                    {this.state.modelPath.map( modelElement => {
+                                        if ( ['textArea', 'textInput'].includes( modelElement ) ) {
+                                            // Text inputs and textareas have placeholder settings.
+                                            return (
+                                                <>
+                                                    <h5>Text Input</h5>
+                                                    <input
+                                                        type='text'
+                                                        id='input-placeholder'
+                                                        defaultValue={this.state['selectedElement'].getAttribute('placeholder')}
+                                                        onChange={( evt ) => {
+                                                            this.editor.execute( 'insertTextArea', 'retained-data-todo', evt.target.value );
+                                                        }}
+                                                    />
+                                                    <label htmlFor='input-placeholder'>Placeholder</label>
+                                                </>
+                                            );
+                                        } else if ( 'slider' === modelElement ) {
+                                            // Sliders have several different settings to change.
+                                            const min = this.state['selectedElement'].getAttribute('min');
+                                            const max = this.state['selectedElement'].getAttribute('max');
+                                            const step = this.state['selectedElement'].getAttribute('step');
+
+                                            return (
+                                                <>
+                                                    <h5>Slider</h5>
+
+                                                    <input
+                                                        type='number'
+                                                        id='input-min'
+                                                        defaultValue={min}
+                                                        onChange={( evt ) => {
+                                                            this.editor.execute( 'insertSlider', 'retained-data-todo', {
+                                                                min: evt.target.value,
+                                                                max: max,
+                                                                step: step,
+                                                            } );
+                                                        }}
+                                                    />
+                                                    <label htmlFor='input-min'>Min</label>
+
+                                                    <input
+                                                        type='number'
+                                                        id='input-max'
+                                                        defaultValue={max}
+                                                        onChange={( evt ) => {
+                                                            this.editor.execute( 'insertSlider', 'retained-data-todo', {
+                                                                min: min,
+                                                                max: evt.target.value,
+                                                                step: step,
+                                                            } );
+                                                        }}
+                                                    />
+                                                    <label htmlFor='input-max'>Max</label>
+
+                                                    <input
+                                                        type='number'
+                                                        id='input-step'
+                                                        defaultValue={step}
+                                                        onChange={( evt ) => {
+                                                            this.editor.execute( 'insertSlider', 'retained-data-todo', {
+                                                                min: min,
+                                                                max: max,
+                                                                step: evt.target.value,
+                                                            } );
+                                                        }}
+                                                    />
+                                                    <label htmlFor='input-step'>Step</label>
+                                                </>
+                                            );
+                                        }
+                                    } ) }
                                 </div>
                                 <div id="toolbar-components">
                                     <ul key="content-part-list" id="widget-list">

--- a/app/javascript/components/ContentEditor.js
+++ b/app/javascript/components/ContentEditor.js
@@ -450,7 +450,7 @@ class ContentEditor extends Component {
                         <div id="toolbar-components">
                             <h4>Insert Component</h4>
 
-                            <ul key="content-part-list" id="widget-list">
+                            <ul key="content-part-list-section" className="widget-list">
                                 <ContentPartPreview
                                     key="insertSection"
                                     enabled={this.state.enabledCommands.includes('insertSection')}
@@ -460,6 +460,8 @@ class ContentEditor extends Component {
                                     }}
                                     {...{name: 'Section', id: uuidv4()}}
                                 />
+                            </ul>
+                            <ul key="content-part-list-questions" className="widget-list">
                                 <ContentPartPreview
                                     key="insertChecklistQuestion"
                                     enabled={this.state.enabledCommands.includes('insertChecklistQuestion')}
@@ -496,6 +498,50 @@ class ContentEditor extends Component {
                                     }}
                                     {...{name: 'Text Area Question', id: uuidv4()}}
                                 />
+                            </ul>
+                            <ul key="content-part-list-content" className="widget-list">
+                                <ContentPartPreview
+                                    key="insertTableContent"
+                                    enabled={this.state.enabledCommands.includes('insertTableContent')}
+                                    onClick={( id ) => {
+                                        const rows = window.prompt('How many rows?', 2);
+                                        const columns = window.prompt('How many columns?', 2);
+                                        this.editor.execute( 'insertTableContent', id , {rows: rows, columns: columns});
+                                        this.editor.editing.view.focus();
+                                    }}
+                                    {...{name: 'Table', id: uuidv4()}}
+                                />
+                                <ContentPartPreview
+                                    key="insertBlockquoteContent"
+                                    enabled={this.state.enabledCommands.includes('insertBlockquoteContent')}
+                                    onClick={( id ) => {
+                                        this.editor.execute( 'insertBlockquoteContent', id );
+                                        this.editor.editing.view.focus();
+                                    }}
+                                    {...{name: 'Quote', id: uuidv4()}}
+                                />
+                                <ContentPartPreview
+                                    key="insertIFrameContent"
+                                    enabled={this.state.enabledCommands.includes('insertIFrameContent')}
+                                    onClick={( id ) => {
+                                        const url = window.prompt('URL', 'http://example.com' );
+                                        this.editor.execute( 'insertIFrameContent', id, url );
+                                        this.editor.editing.view.focus();
+                                    }}
+                                    {...{name: 'iFrame', id: uuidv4()}}
+                                />
+                                <ContentPartPreview
+                                    key="insertVideoContent"
+                                    enabled={this.state.enabledCommands.includes('insertVideoContent')}
+                                    onClick={( id ) => {
+                                        const url = window.prompt('URL', 'https://www.youtube.com/embed/yyRrKMb8oIg?rel=0' );
+                                        this.editor.execute( 'insertVideoContent', id, url );
+                                        this.editor.editing.view.focus();
+                                    }}
+                                    {...{name: 'Video', id: uuidv4()}}
+                                />
+                            </ul>
+                            <ul key="content-part-list-elements" className="widget-list">
                                 <ContentPartPreview
                                     key="insertTextArea"
                                     enabled={this.state.enabledCommands.includes('insertTextArea')}
@@ -539,46 +585,8 @@ class ContentEditor extends Component {
                                     }}
                                     {...{name: 'Image (URL)', id: uuidv4()}}
                                 />
-                                <ContentPartPreview
-                                    key="insertTableContent"
-                                    enabled={this.state.enabledCommands.includes('insertTableContent')}
-                                    onClick={( id ) => {
-                                        const rows = window.prompt('How many rows?', 2);
-                                        const columns = window.prompt('How many columns?', 2);
-                                        this.editor.execute( 'insertTableContent', id , {rows: rows, columns: columns});
-                                        this.editor.editing.view.focus();
-                                    }}
-                                    {...{name: 'Table', id: uuidv4()}}
-                                />
-                                <ContentPartPreview
-                                    key="insertBlockquoteContent"
-                                    enabled={this.state.enabledCommands.includes('insertBlockquoteContent')}
-                                    onClick={( id ) => {
-                                        this.editor.execute( 'insertBlockquoteContent', id );
-                                        this.editor.editing.view.focus();
-                                    }}
-                                    {...{name: 'Quote', id: uuidv4()}}
-                                />
-                                <ContentPartPreview
-                                    key="insertIFrameContent"
-                                    enabled={this.state.enabledCommands.includes('insertIFrameContent')}
-                                    onClick={( id ) => {
-                                        const url = window.prompt('URL', 'http://example.com' );
-                                        this.editor.execute( 'insertIFrameContent', id, url );
-                                        this.editor.editing.view.focus();
-                                    }}
-                                    {...{name: 'iFrame', id: uuidv4()}}
-                                />
-                                <ContentPartPreview
-                                    key="insertVideoContent"
-                                    enabled={this.state.enabledCommands.includes('insertVideoContent')}
-                                    onClick={( id ) => {
-                                        const url = window.prompt('URL', 'https://www.youtube.com/embed/yyRrKMb8oIg?rel=0' );
-                                        this.editor.execute( 'insertVideoContent', id, url );
-                                        this.editor.editing.view.focus();
-                                    }}
-                                    {...{name: 'Video', id: uuidv4()}}
-                                />
+                            </ul>
+                            <ul key="content-part-list-rtm" className="widget-list">
                                 <ContentPartPreview
                                     key="insertRateThisModuleQuestion"
                                     enabled={this.state.enabledCommands.includes('insertRateThisModuleQuestion')}

--- a/spec/feature/course_contents/smoke_spec.rb
+++ b/spec/feature/course_contents/smoke_spec.rb
@@ -38,9 +38,6 @@ RSpec.describe CourseContentsController, type: :routing do
           # FIXME: Temporarily disable server errors, to stop the test from failing on the question icon 404
           Capybara.raise_server_errors = false
 
-          # Hide the ckeditor inspector.
-          find("button.ck-inspector-navbox__navigation__toggle").click
-
           # Insert a question.
           find("li", text: "Section").click
           find("li", text: "Checklist Question").click


### PR DESCRIPTION
Summary: Add a toolbar to the right sidebar that only shows up if you have certain elements selected. E.g. when you click on a textarea, it shows a toolbar that lets you change the textarea's placeholder attribute.

Task: https://app.asana.com/0/1142638035116665/1155859225081719/f

We didn't design anything for this, so it's not pretty. Here's what this looks like:

<img width="1178" alt="Screen Shot 2020-01-17 at 3 37 55 PM" src="https://user-images.githubusercontent.com/1382374/72647932-5b8e5980-393f-11ea-9b9f-3afb0b7292ce.png">

<img width="1178" alt="Screen Shot 2020-01-17 at 3 39 24 PM" src="https://user-images.githubusercontent.com/1382374/72648016-8ed0e880-393f-11ea-864c-b3bab7aab715.png">

This PR also includes some other, smaller right-sidebar tasks: 

✓ Editor JS: Implement UI for sliders (right sidebar)
✓ Editor JS/CK: Allow setting placeholder text for textareas/inputs (right sidebar)
✓ Editor JS: Remove tabs from right sidebar
✓ Design/Editor JS: organize buttons on right sidebar
