### PR TITLE
Cleanup up SSO related specs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,5 @@ DATABASE_PASSWORD=password
 SSO_URL=http://platformweb:3020/cas
 CODACY_PROJECT_TOKEN=
 GEM_HOME=/gems
+VCR_JOIN_SERVER=joinweb:3001
+VCR_CANVAS_SERVER=canvasweb:3000

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ tmp/
 log/
 /*.dev
 
+# Ignore vim related files
+*.swp
+*.swo
+
 ## Ignore bundler config
 /.bundle/
 /vendor/bundle

--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ in the dev env so that when you get an error page in the browser, it includes an
 so that you can inspect the variables or run code. E.g. Type `instance_variables` or `local_variables` to see a list.
 Or, for example you can inspect one such as the `@current_user` by writing `instance_variable_get(:@current_user)`
 
+We also have the pry and rescue gems so that you can break and debug code. Here is an example for how to debug
+a spec that is throwing an exception.
+    bundle exec rescue rspec spec/a_failing_spec.rb --format documentation   
+
 **TODO:** talk about pry and other dev and troubleshooting techniques.
 
 ### Accessibility testing

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -33,6 +33,9 @@ Rails.application.configure do
   # Store uploaded files on the local file system in a temporary directory.
   config.active_storage.service = :test
 
+  # Tests should be mostly silent. Only log errors.
+  config.log_level = :error
+
   config.action_mailer.perform_caching = false
 
   # Tell Action Mailer not to deliver emails to the real world.

--- a/config/rubycas.yml
+++ b/config/rubycas.yml
@@ -50,7 +50,7 @@ test:
   <<: *default
   log:
     output: 
-    level: DEBUG
+    level: ERROR
   public_site_domain: joinweb
   # this should be the *top* domain - so even for staging, it should be .join.bebraven.org stilldefault_service: http://canvasweb/login/cas
   cookie_domain: .localhost 


### PR DESCRIPTION
- Make running the specs silent on success instead of printing out a bajillion debug logs.
- Update .env.example to reflect how it should be configured to make the SSO specs pass.

Note: the Selenium driven smoke_spec.rb tests still fail for me. See the selenium_specs branch for more details of my investigation and attempt to fix, but I'm deprioritizing that for now. Also note that the SSO specs don't actually use Selenium b/c they don't need a javascript driver.