### PR TITLE
Fix high CPU usage on a Mac when running Docker container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,9 @@ RUN apk add --update --no-cache \
     nodejs \
     yarn \
     tzdata \
-    git 
+    libnotify \
+    git \
+    vim
 
 COPY Gemfile* /usr/src/app/
 COPY package.json /usr/src/app/

--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ group :development do
   gem 'guard-rails', require: false
   gem 'guard-rspec', require: false
   gem 'guard-livereload', require: false
+  gem 'libnotify', require: false
   gem 'rack-livereload'
   gem 'guard-webpacker'
   gem 'webpacker-react', "~> 1.0.0.beta.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,6 +194,8 @@ GEM
     libhoney (1.14.2)
       addressable (~> 2.0)
       http (>= 2.0, < 5.0)
+    libnotify (0.9.4)
+      ffi (>= 1.0.11)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -432,6 +434,7 @@ DEPENDENCIES
   guard-yarn
   honeycomb-beeline
   jbuilder (~> 2.7)
+  libnotify
   listen (>= 3.0.5, < 3.2)
   paranoia
   pg

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,14 @@ services:
       - .env
     networks:
       - bravendev
-    command: bundle exec guard -dip
+    # Note: there are some issues with the listen gem and certain editors
+    # where gaurd won't detect changes made from the host machine on a Mac
+    # inside the container when the volume is mounted. For VIM, you need to add
+    #   set backupcopy=yes 
+    # in your .vimrc
+    # See: https://github.com/guard/listen/issues/434
+    # Also, if you force polling it will absolutely destroy your CPU.
+    command: bundle exec guard -di
 
   platformdb:
     image: postgres


### PR DESCRIPTION
See: https://app.asana.com/0/1156506513832825/1158558207611705

We were running guard with force polling on because using the filesystem
event notificaiton stuff wasn't working. It was pinning the CPU at 100%+
This commit adds libnotify to the Docker container, adds the gem to use it,
and then runs gaurd without forced polling.

**IMPORTANT NOTE:** there are issues with certain editors, like vim, when you
edit from the host machine. For vim, you have to add this setting to your
.vimrc file:
`set backupcopy=yes`

See the following for more details
- https://github.com/guard/listen/issues/434
- https://github.com/guard/listen/issues/420

TESTING:
- Rebuilt the container and edited an .erb file from vim on the host Mac machine
  with `backupcopy=yes` turned on. The change was live reloaded.
- Tried with VSCODE as well. That worked.
- Oh, and my machine is quite as a mouse now. Going into the container and running `top` shows no pinned CPU for the guard process.