### PR TITLE
Add rake task to restart dynos.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,3 +94,9 @@ gem 'rubycas-server-activerecord'
 
 # Honeycomb
 gem 'honeycomb-beeline', require: false
+
+# Allows us to write rake tasks that can programatticaly run Heroku commands
+# using their API. E.g. create a task to restart a dyno so it can be run
+# in the middle of the night to avoid downtime when users are on the platform
+# See: https://github.com/heroku/platform-api
+gem 'platform-api', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,9 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     erubi (1.9.0)
+    erubis (2.7.0)
     eventmachine (1.2.7)
+    excon (0.72.0)
     execjs (2.7.0)
     factory_bot (5.1.1)
       activesupport (>= 4.2.0)
@@ -170,6 +172,11 @@ GEM
     guard-yarn (1.0.0)
       guard-compat (~> 1.1)
     hashdiff (1.0.0)
+    heroics (0.0.25)
+      erubis (~> 2.0)
+      excon
+      moneta
+      multi_json (>= 1.9.2)
     honeycomb-beeline (1.3.0)
       libhoney (~> 1.8)
     http (4.2.0)
@@ -216,6 +223,7 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.12.2)
+    moneta (1.0.0)
     msgpack (1.3.1)
     multi_json (1.14.1)
     multipart-post (2.1.1)
@@ -234,6 +242,9 @@ GEM
     parser (2.6.5.0)
       ast (~> 2.4.0)
     pg (1.1.4)
+    platform-api (2.2.0)
+      heroics (~> 0.0.25)
+      moneta (~> 1.0.0)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -438,6 +449,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   paranoia
   pg
+  platform-api
   pry-rescue
   pry-stack_explorer
   puma (~> 3.12)

--- a/lib/tasks/heroku.rb
+++ b/lib/tasks/heroku.rb
@@ -1,0 +1,23 @@
+namespace :heroku do
+  namespace :app do
+    require 'platform-api'
+    
+      # Example call: HEROKU_OAUTH_TOKEN=my-token HEROKU_APP_NAME=my-app bundle exec rake heroku:app:restart_dyno[web]
+      desc "Restart a dyno."
+      task :restart_dyno, [:dyno_name] => :environment do |t, args|
+
+        # Note: get the HEROKU_OAUTH_TOKEN using:
+        #   heroku authorizations:create -d "Portal Admin API token" 
+        heroku = PlatformAPI.connect_oauth(ENV['HEROKU_OAUTH_TOKEN'])
+
+        # Note: HEROKU_APP_NAME is supposed to be availble on a normal dyno (in addition to Review Apps) after running:
+        #   heroku labs:enable runtime-dyno-metadata
+        # but it didn't seem to be so I set it manually
+        heroku.dyno.restart(ENV['HEROKU_APP_NAME'], args[:dyno_name])
+
+      end
+
+  end # Namespace: app
+
+end # Namespace: heroku
+


### PR DESCRIPTION
This is intended to be used from the Scheduler add-on
(or some other add-on) to restart the dyno in the middle of
the night daily so that we're not at the whims of the dyno
manager cycling it.

TESTING:
- After creating an oauth token using
   heroku authorizations:create -d "Platform Admin API token" -s write
 I ran:
   HEROKU_OAUTH_TOKEN=my-token HEROKU_APP_NAME=my-app bundle exec rake heroku:app:restart_dyno[web]
 and verified that the dyno restarted