### PR TITLE
Attempt to fix review apps database population.

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,15 +1,21 @@
 {
+  "buildpacks": [
+    { "url": "heroku/ruby" }
+  ],
   "environments": {
     "test": {
       "buildpacks": [
-        { "url": "https://github.com/heroku/heroku-buildpack-google-chrome" },
-        { "url": "heroku/ruby" }
+        { "url": "https://github.com/heroku/heroku-buildpack-google-chrome" }
       ],
       "addons": ["heroku-postgresql:in-dyno"],
       "scripts": {
-        "postdeploy": "bundle exec rake db:migrate db:seed",
         "test-setup": "yarn install",
         "test": "bundle exec rspec && yarn test"
+      }
+    },
+    "review": {
+      "scripts": {
+        "postdeploy": "bundle exec rake db:schema:load db:seed"
       }
     }
   }

--- a/app.json
+++ b/app.json
@@ -15,7 +15,7 @@
     },
     "review": {
       "scripts": {
-        "postdeploy": "bundle exec rake db:schema:load db:seed"
+        "postdeploy": "bundle exec rake db:schema:load db:dummies"
       }
     }
   }

--- a/db/dummies.rb
+++ b/db/dummies.rb
@@ -2,8 +2,12 @@
 # This SHOULD NOT be used in production, which is why it's separate from the
 # seeds file.
 
+if User.count == 0
+  User.create [{first_name: 'Dev', last_name: 'Admin', email: 'admin@beyondz.org', admin: true}]
+end
+
 user_count = User.count
-FactoryBot.create_list(:user, 5) unless user_count > 0
+FactoryBot.create_list(:user, 5) unless user_count > 1
 puts "Created #{User.count - user_count} users"
 
 program = Program.find_or_create_by name: 'SJSU'


### PR DESCRIPTION
The app.json had everything in the "test" environment, so the
postdeploy script wasn't running. Move the review apps related
postdeploy to the "review" environment and cleanup the buildpack
that applies to all environments.

TESTING:
- F.It, we'll do it live!
  (it's the only option)