### PR TITLE
Fixes to app.json -- top level buildpacks didn't seem to work.

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,11 +1,9 @@
 {
-  "buildpacks": [
-    { "url": "heroku/ruby" }
-  ],
   "environments": {
     "test": {
       "buildpacks": [
-        { "url": "https://github.com/heroku/heroku-buildpack-google-chrome" }
+        { "url": "https://github.com/heroku/heroku-buildpack-google-chrome" },
+        { "url": "heroku/ruby" }
       ],
       "addons": ["heroku-postgresql:in-dyno"],
       "scripts": {
@@ -14,6 +12,9 @@
       }
     },
     "review": {
+      "buildpacks": [
+        { "url": "heroku/ruby" }
+      ],
       "scripts": {
         "postdeploy": "bundle exec rake db:schema:load db:dummies"
       }


### PR DESCRIPTION
Was getting the following error for CI when deploying. Also, the
ruby buildpack didn't show up in the log.

bash: yarn: command not found
-----> test-setup command `yarn install` failed with exit status 127