### PR TITLE
DRY-up our controllers a bit with some meta-programming

### DIFF
--- a/app/controllers/access_tokens_controller.rb
+++ b/app/controllers/access_tokens_controller.rb
@@ -1,5 +1,4 @@
 class AccessTokensController < ApplicationController
-  before_action :set_access_token, only: [:show, :edit, :update, :destroy]
 
   # GET /access_tokens
   # GET /access_tokens.json
@@ -62,11 +61,6 @@ class AccessTokensController < ApplicationController
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_access_token
-      @access_token = AccessToken.find(params[:id])
-    end
-
     # Never trust parameters from the scary internet, only allow the white list through.
     def access_token_params
       params.require(:access_token).permit(:name)

--- a/app/controllers/access_tokens_controller.rb
+++ b/app/controllers/access_tokens_controller.rb
@@ -3,7 +3,6 @@ class AccessTokensController < ApplicationController
   # GET /access_tokens
   # GET /access_tokens.json
   def index
-    @access_tokens = AccessToken.all
   end
 
   # GET /access_tokens/1

--- a/app/controllers/access_tokens_controller.rb
+++ b/app/controllers/access_tokens_controller.rb
@@ -13,7 +13,6 @@ class AccessTokensController < ApplicationController
 
   # GET /access_tokens/new
   def new
-    @access_token = AccessToken.new
   end
 
   # GET /access_tokens/1/edit

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,9 @@
 require 'rubycas-server-core/tickets'
+require 'dry_crud'
 
 class ApplicationController < ActionController::Base
   include RubyCAS::Server::Core::Tickets
+  include DryCrud::Controllers
 
   before_action :authenticate_user!
   before_action :ensure_admin!

--- a/app/controllers/cas_controller.rb
+++ b/app/controllers/cas_controller.rb
@@ -16,6 +16,11 @@ class CasController < ApplicationController
   include RubyCAS::Server::Core::Tickets::Validations
   include RubyCAS::Server::Core::Tickets::Generations
 
+  # Non-standard controller without normal CRUD methods. Disable the convenience module.
+  def dry_crud_enabled?
+    false
+  end
+
   def login
     # make sure there's no caching
     request.headers['Pragma'] = 'no-cache'

--- a/app/controllers/course_contents_controller.rb
+++ b/app/controllers/course_contents_controller.rb
@@ -3,7 +3,6 @@ class CourseContentsController < ApplicationController
   # GET /course_contents
   # GET /course_contents.json
   def index
-    @course_contents = CourseContent.all
   end
 
   # GET /course_contents/1

--- a/app/controllers/course_contents_controller.rb
+++ b/app/controllers/course_contents_controller.rb
@@ -1,5 +1,4 @@
 class CourseContentsController < ApplicationController
-  before_action :set_course_content, only: [:show, :edit, :update, :destroy, :publish]
 
   # GET /course_contents
   # GET /course_contents.json
@@ -76,10 +75,6 @@ class CourseContentsController < ApplicationController
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_course_content
-      @course_content = CourseContent.find(params[:id])
-    end
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def course_content_params

--- a/app/controllers/course_contents_controller.rb
+++ b/app/controllers/course_contents_controller.rb
@@ -13,7 +13,6 @@ class CourseContentsController < ApplicationController
 
   # GET /course_contents/new
   def new
-    @course_content = CourseContent.new
   end
 
   # GET /course_contents/1/edit

--- a/app/controllers/industries_controller.rb
+++ b/app/controllers/industries_controller.rb
@@ -3,7 +3,6 @@ class IndustriesController < ApplicationController
   # GET /industries
   # GET /industries.json
   def index
-    @industries = Industry.all
   end
 
   # GET /industries/1

--- a/app/controllers/industries_controller.rb
+++ b/app/controllers/industries_controller.rb
@@ -13,7 +13,6 @@ class IndustriesController < ApplicationController
 
   # GET /industries/new
   def new
-    @industry = Industry.new
   end
 
   # GET /industries/1/edit

--- a/app/controllers/industries_controller.rb
+++ b/app/controllers/industries_controller.rb
@@ -1,5 +1,4 @@
 class IndustriesController < ApplicationController
-  before_action :set_industry, only: [:show, :edit, :update, :destroy]
 
   # GET /industries
   # GET /industries.json
@@ -62,10 +61,6 @@ class IndustriesController < ApplicationController
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_industry
-      @industry = Industry.find(params[:id])
-    end
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def industry_params

--- a/app/controllers/interests_controller.rb
+++ b/app/controllers/interests_controller.rb
@@ -3,7 +3,6 @@ class InterestsController < ApplicationController
   # GET /interests
   # GET /interests.json
   def index
-    @interests = Interest.all
   end
 
   # GET /interests/1

--- a/app/controllers/interests_controller.rb
+++ b/app/controllers/interests_controller.rb
@@ -1,5 +1,4 @@
 class InterestsController < ApplicationController
-  before_action :set_interest, only: [:show, :edit, :update, :destroy]
 
   # GET /interests
   # GET /interests.json
@@ -62,10 +61,6 @@ class InterestsController < ApplicationController
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_interest
-      @interest = Interest.find(params[:id])
-    end
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def interest_params

--- a/app/controllers/interests_controller.rb
+++ b/app/controllers/interests_controller.rb
@@ -13,7 +13,6 @@ class InterestsController < ApplicationController
 
   # GET /interests/new
   def new
-    @interest = Interest.new
   end
 
   # GET /interests/1/edit

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -1,5 +1,4 @@
 class LocationsController < ApplicationController
-  before_action :set_location, only: [:show]
 
   # GET /locations
   # GET /locations.json
@@ -14,7 +13,4 @@ class LocationsController < ApplicationController
 
   private
   
-  def set_location
-    @location = Location.find(params[:id])
-  end
 end

--- a/app/controllers/majors_controller.rb
+++ b/app/controllers/majors_controller.rb
@@ -13,7 +13,6 @@ class MajorsController < ApplicationController
 
   # GET /majors/new
   def new
-    @major = Major.new
   end
 
   # GET /majors/1/edit

--- a/app/controllers/majors_controller.rb
+++ b/app/controllers/majors_controller.rb
@@ -1,5 +1,4 @@
 class MajorsController < ApplicationController
-  before_action :set_major, only: [:show, :edit, :update, :destroy]
 
   # GET /majors
   # GET /majors.json
@@ -62,10 +61,6 @@ class MajorsController < ApplicationController
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_major
-      @major = Major.find(params[:id])
-    end
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def major_params

--- a/app/controllers/postal_codes_controller.rb
+++ b/app/controllers/postal_codes_controller.rb
@@ -1,4 +1,10 @@
 class PostalCodesController < ApplicationController
+  before_action :set_postal_code, only: [:show]
+
+  # DryCrud doesn't handle: PostalCode.find_by(code: params[:id])
+  def dry_crud_enabled?
+    false
+  end
 
   # GET /postal_codes
   # GET /postal_codes.json
@@ -27,5 +33,7 @@ class PostalCodesController < ApplicationController
   end
 
   private
-
+    def set_postal_code
+      @postal_code = PostalCode.find_by(code: params[:id])
+    end
 end

--- a/app/controllers/postal_codes_controller.rb
+++ b/app/controllers/postal_codes_controller.rb
@@ -1,5 +1,4 @@
 class PostalCodesController < ApplicationController
-  before_action :set_postal_code, only: [:show]
 
   # GET /postal_codes
   # GET /postal_codes.json
@@ -29,7 +28,4 @@ class PostalCodesController < ApplicationController
 
   private
 
-  def set_postal_code
-    @postal_code = PostalCode.find_by(code: params[:id])
-  end
 end

--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -8,7 +8,6 @@ class ProgramsController < ApplicationController
 
   # GET /programs/new
   def new
-    @program = Program.new
   end
 
   # GET /programs/1/edit

--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -1,5 +1,4 @@
 class ProgramsController < ApplicationController
-  before_action :set_program, only: [:edit, :update, :destroy]
 
   # GET /programs
   # GET /programs.json
@@ -57,11 +56,6 @@ class ProgramsController < ApplicationController
   end
 
   private
-
-  # Use callbacks to share common setup or constraints between actions.
-  def set_program
-    @program = Program.find(params[:id])
-  end
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def program_params

--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -3,7 +3,6 @@ class ProgramsController < ApplicationController
   # GET /programs
   # GET /programs.json
   def index
-    @programs = Program.all
   end
 
   # GET /programs/new

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -3,7 +3,6 @@ class RolesController < ApplicationController
   # GET /roles
   # GET /roles.json
   def index
-    @roles = Role.all
   end
 
   # GET /roles/new

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -1,5 +1,4 @@
 class RolesController < ApplicationController
-  before_action :set_role, only: [:edit, :update, :destroy]
 
   # GET /roles
   # GET /roles.json
@@ -57,11 +56,6 @@ class RolesController < ApplicationController
   end
 
   private
-
-  # Use callbacks to share common setup or constraints between actions.
-  def set_role
-    @role = Role.find(params[:id])
-  end
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def role_params

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -8,7 +8,6 @@ class RolesController < ApplicationController
 
   # GET /roles/new
   def new
-    @role = Role.new
   end
 
   # GET /roles/1/edit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,4 @@
 class UsersController < ApplicationController
-  before_action :set_user, only: [:show]
 
   # GET /users
   # GET /users.json
@@ -16,8 +15,4 @@ class UsersController < ApplicationController
 
   private
 
-  # Use callbacks to share common setup or constraints between actions.
-  def set_user
-    @user = User.find(params[:id])
-  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,6 @@ class UsersController < ApplicationController
   # GET /users
   # GET /users.json
   def index
-    @users = User.all
   end
 
   # GET /users/1

--- a/lib/dry_crud.rb
+++ b/lib/dry_crud.rb
@@ -1,0 +1,22 @@
+# Helps DRY up your controllers. 
+module DryCrud
+
+  module Controllers
+    extend ActiveSupport::Concern
+  
+    # DRY's up the show method by setting the instance variable
+    # to the current instance of the module
+    included do
+      before_action :set_model_instance, only: [:show, :edit, :update, :destroy, :publish]
+    end
+      
+    # E.g. if your controller is called LessonsController this will set the instance variable like so:
+    # @lesson = Lesson.find(params[:id]) 
+    def set_model_instance
+      model_class = controller_path.classify.constantize
+      instance_variable_set(:"@#{model_class.model_name.param_key}", model_class.find(params[:id]))
+    end
+
+  end # Controllers
+
+end # DryCrud

--- a/lib/dry_crud.rb
+++ b/lib/dry_crud.rb
@@ -8,15 +8,29 @@ module DryCrud
     # to the current instance of the module
     included do
       before_action :set_model_instance, only: [:show, :edit, :update, :destroy, :publish]
+      before_action :new_model_instance, only: [:new]
+
     end
       
     # E.g. if your controller is called LessonsController this will set the instance variable like so:
     # @lesson = Lesson.find(params[:id]) 
     def set_model_instance
-      model_class = controller_path.classify.constantize
-      instance_variable_set(:"@#{model_class.model_name.param_key}", model_class.find(params[:id]))
+      instance_variable_set(instance_variable_name, model_class.find(params[:id]))
     end
 
+    # E.g. if your controller is called LessonsController this will create a new @lesson instance variable
+    def new_model_instance
+      instance_variable_set(instance_variable_name, model_class.new)
+    end
+
+    private
+      def model_class
+        @model_class ||= controller_path.classify.constantize
+      end
+
+      def instance_variable_name
+        @ivar_name ||= :"@#{model_class.model_name.param_key}"
+      end
   end # Controllers
 
 end # DryCrud

--- a/lib/dry_crud.rb
+++ b/lib/dry_crud.rb
@@ -3,34 +3,57 @@ module DryCrud
 
   module Controllers
     extend ActiveSupport::Concern
-  
-    # DRY's up the show method by setting the instance variable
-    # to the current instance of the module
+
+    # DRY's up the index, show, edit, update, destroy, new, create and publish methods
+    # by setting the appropriate instance variables for the corresponding model
+    #
+    # NOTE: you can alway override this behavior by defining whatever you want in the 
+    # associated controller's index, show, edit, etc methods.
     included do
+      before_action :set_models_instance, only: [:index]
       before_action :set_model_instance, only: [:show, :edit, :update, :destroy, :publish]
       before_action :new_model_instance, only: [:new]
+    end 
 
+    # Override this in any subclass that needs to turn this behavior off.
+    #
+    # Note: there must be a better way to do this, but I couldn't figure it out.
+    # This module is included in ApplicationController and all controller inherit that,
+    # so if I try to rely on respond_to?(), it applies to ApplicationController and not the subclass.
+    def dry_crud_enabled?
+      true
     end
-      
+
+  protected
+
+    # E.g. if your controller is called LessonsController this will set the instance variable like so:
+    # @lessons = Lessons.all
+    def set_models_instance
+      instance_variable_set(:"@#{instance_variable_name.pluralize}", model_class.all) if dry_crud_enabled? && model_class
+    end
+
     # E.g. if your controller is called LessonsController this will set the instance variable like so:
     # @lesson = Lesson.find(params[:id]) 
     def set_model_instance
-      instance_variable_set(instance_variable_name, model_class.find(params[:id]))
+      instance_variable_set(:"@#{instance_variable_name}", model_class.find(params[:id])) if dry_crud_enabled? && model_class
     end
 
-    # E.g. if your controller is called LessonsController this will create a new @lesson instance variable
+    # E.g. if your controller is called LessonsController this will create a new instance variable like so:
+    # @lesson = Lesson.new
     def new_model_instance
-      instance_variable_set(instance_variable_name, model_class.new)
+      instance_variable_set(:"@#{instance_variable_name}", model_class.new) if dry_crud_enabled? && model_class
     end
 
-    private
-      def model_class
-        @model_class ||= controller_path.classify.constantize
-      end
+  private
 
-      def instance_variable_name
-        @ivar_name ||= :"@#{model_class.model_name.param_key}"
-      end
+    def model_class
+      @model_class ||= controller_path.classify.safe_constantize
+    end
+
+    def instance_variable_name
+      model_class.model_name.param_key
+    end
+
   end # Controllers
 
 end # DryCrud


### PR DESCRIPTION
This allows us to create new controllers that inherit from ApplicationController and they auto-magically have the instance variables set that `index`, `show`, and `edit` CRUD methods rely on. I'll be adding more functionality to this for nested resources [over here](https://github.com/bebraven/platform/pull/85#discussion_r376598338) which sparked this PR.

Note: this is by no means high on the priority list of things to do, but it was fun to tinker with and getting some of this stuff setup early one just means less and less code to maintain in multiple spots, so I think it's worth it on both fronts.

TESTING
- all specs pass
- clicked around the various routes to make sure that show, edit, and index routes don't throw exceptions

NOTE:
- I borrowed heavily from for implementation inspiration: https://github.com/codez/dry_crud