### PR TITLE
Make working with the dev database easier.

### DIFF
--- a/docker-compose/scripts/dbconnect.sh
+++ b/docker-compose/scripts/dbconnect.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 # This connects to the development database. The user and database name are in docker-compose.yml
-docker-compose exec platformdb psql -U user
+docker-compose exec platformdb psql -U user platform_development

--- a/docker-compose/scripts/dbrefresh.sh
+++ b/docker-compose/scripts/dbrefresh.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+echo "Refreshing your local dev database"
+
+docker-compose down
+docker volume rm platform_db-platform
+docker-compose up -d
+sleep 5 # wait for containers to be up and accepting connections
+
+docker-compose exec platformweb bundle exec rake db:create db:schema:load db:dummies
+
+
+


### PR DESCRIPTION
When I wanted to blow away my dev db my natural inclination was to run `docker-compose exec platformweb rake db:drop db:create` but that doesn't work b/c there are active DB connections. Adding a script (like all our other repos have) to blow away and refresh the dev db.

- adding a ./docker-compose/scripts/dbrefresh.sh to blow away your dev db
  entirely and make it fresh
- running the alias `devdb` (or the full script ./docker-compose/scripts/dbconnect.sh)
  now connects to the actual database instead of just the db server.

Note: for now db:dummies is how we're seeding a dev db, but we'll likely change that
to somehow load a dev version of staging/prod at some point

TESTING: 
- ran the script. new db