### PR TITLE
Revert "marks some failing tests as pending"

### DIFF
--- a/spec/controllers/cas/login_spec.rb
+++ b/spec/controllers/cas/login_spec.rb
@@ -53,18 +53,18 @@ RSpec.describe CasController, type: :routing do
         let(:username) { valid_user[:email] }
         let(:password) { valid_user[:password] }
         
-        xit "logs in successfully" do
+        it "logs in successfully" do
           # Ensure that the login was successful
           expect(current_url).to include(return_service)
           expect(current_url).to include("ticket")
         end
 
-        xit "validates existing tickets" do
+        it "validates existing tickets" do
           @params = parse_query(current_url, "&?,")
           expect(@params).to include("ticket")
         end
 
-        xit "generates new ticket when revisiting login page" do
+        it "generates new ticket when revisiting login page" do
           # Get current ticket to check against next generated ticket
           @params = parse_query(current_url, "&?,")
           visit "/cas/login?service=#{url_encode(return_service)}"

--- a/spec/controllers/cas/logout_spec.rb
+++ b/spec/controllers/cas/logout_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe CasController, type: :routing do
             fill_and_submit_login(username, password)
           end
         end
-        xit "logout successfully" do
+        it "logout successfully" do
           visit "/cas/logout"
           expect(page).to have_content('You have successfully logged out')
         end

--- a/spec/controllers/cas/proxy_validate_spec.rb
+++ b/spec/controllers/cas/proxy_validate_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe CasController, type: :routing do
             fill_and_submit_login(username, password)
           end
         end
-        xit "contains a ticket" do
+        it "contains a ticket" do
           expect(current_url).to include("ticket")
         end 
         context "with valid proxy ticket" do
@@ -32,7 +32,7 @@ RSpec.describe CasController, type: :routing do
             @params = parse_query(current_url, "&?,")
             visit "/cas/proxyValidate?ticket=#{@params["ticket"]}&service=#{return_service}"      
           end
-          xit "validates proxy ticket" do
+          it "validates proxy ticket" do
             # Capybara can't handle XMLs properly, use the result string 
             expect(page.body).to include("authenticationSuccess")
             expect(page.body).to include(valid_user[:email])

--- a/spec/controllers/cas/service_validate_spec.rb
+++ b/spec/controllers/cas/service_validate_spec.rb
@@ -40,13 +40,13 @@ RSpec.describe CasController, type: :routing do
           before(:each) do
             @params = parse_query(current_url, "&?,")
           end
-          xit "logs in successfully and validates service" do
+          it "logs in successfully and validates service" do
             visit "/cas/serviceValidate?ticket=#{@params['ticket']}&service=#{url_encode(return_service)}"
             expect(page.body).to include("cas:authenticationSuccess>")
             expect(page.body).to include('platform_user')
           end
 
-          xit "logs in successfully and validates service with proxy url" do
+          it "logs in successfully and validates service with proxy url" do
             pending "Need to get proxy service set up"
 
             visit "/cas/serviceValidate?ticket=#{@params['ticket']}&service=#{url_encode(return_service)}&pgtUrl=#{proxy_service}"
@@ -54,7 +54,7 @@ RSpec.describe CasController, type: :routing do
             expect(page.body).to include('platform_usr')
           end
 
-          xit "fails validate a service because no service specified" do
+          it "fails validate a service because no service specified" do
             # Attempt to validate the service
             visit "/cas/serviceValidate?ticket=#{@params['ticket']}"
             expect(page.body).to include("cas:authenticationFailure")
@@ -62,7 +62,7 @@ RSpec.describe CasController, type: :routing do
             expect(page.body).to include("Ticket or service parameter was missing in the request.")
           end
 
-          xit "fails validate a service because ticket is consumed" do
+          it "fails validate a service because ticket is consumed" do
             # Validate service ticket
             visit "/cas/serviceValidate?ticket=#{@params["ticket"]}&service=#{return_service}"
 

--- a/spec/controllers/cas/validate_spec.rb
+++ b/spec/controllers/cas/validate_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe CasController, type: :routing do
         let(:username) { valid_user[:email] }
         let(:password) { valid_user[:password] }
 
-        xit "contain a ticket" do
+        it "contain a ticket" do
           expect(current_url).to include("ticket")
         end
 
@@ -44,7 +44,7 @@ RSpec.describe CasController, type: :routing do
           before(:each) do
             @params = parse_query(current_url, "&?,")
           end
-          xit "validate a service ticket" do
+          it "validate a service ticket" do
             # Validate the ticket
             visit "/cas/validate?ticket=#{@params["ticket"]}&service=#{return_service}"
             result = JSON.parse(page.body)
@@ -54,7 +54,7 @@ RSpec.describe CasController, type: :routing do
             expect(result["user"]).to eq(username)
           end
 
-          xit "fails validate a service ticket because no service specified" do
+          it "fails validate a service ticket because no service specified" do
             # Attempt to validate the ticket
             visit "/cas/validate?ticket=#{@params["ticket"]}"
             result = JSON.parse(page.body)
@@ -65,7 +65,7 @@ RSpec.describe CasController, type: :routing do
             expect(result["error"]["message"]).to include("Ticket or service parameter was missing in the request.")
           end
 
-          xit "fails validate a service ticket because it is consumed" do
+          it "fails validate a service ticket because it is consumed" do
             # Validate service ticket
             visit "/cas/validate?ticket=#{@params["ticket"]}&service=#{return_service}"
   

--- a/spec/feature/course_contents/smoke_spec.rb
+++ b/spec/feature/course_contents/smoke_spec.rb
@@ -27,14 +27,14 @@ RSpec.describe CourseContentsController, type: :routing do
         let(:username) { valid_user[:email] }
         let(:password) { valid_user[:password] }
         
-        xit "loads the editor view and renders react components" do
+        it "loads the editor view and renders react components" do
           expect(current_url).to include(return_service)
           expect(page).to have_title("Braven Platform")
           expect(page).to have_selector("h1", text: "BRAVEN CONTENT EDITOR")
           expect(page).to have_content("Checklist Question")
         end
 
-        xit "loads the editor view and renders react components" do
+        it "loads the editor view and renders react components" do
           # FIXME: Temporarily disable server errors, to stop the test from failing on the question icon 404
           Capybara.raise_server_errors = false
 


### PR DESCRIPTION
Reverts bebraven/platform#119

The `Test run config vars` under Heroku CI settings needed to be updated to change `SSO_URL` from `http://stagingplatform.bebraven.org/cas/` to `https://stagingplatform.bebraven.org/cas/`.

For good measure, I added `FORCE_SSL=true` since that's the mode we run staging and prod in.