### PR TITLE
Allow all known "data-bz-*" attributes on all remaining input types

### DIFF
--- a/app/javascript/ckeditor/checklistquestionediting.js
+++ b/app/javascript/ckeditor/checklistquestionediting.js
@@ -153,9 +153,9 @@ export default class ChecklistQuestionEditing extends Plugin {
 
                 return modelWriter.createElement( 'checkboxInput', new Map( [
                     ...filterAllowedAttributes(viewElement.getAttributes()),
-                    ['id', id],
-                    ['data-bz-retained', id],
-                    ['data-correctness', viewElement.getAttribute('data-correctness') || '']
+                    [ 'id', id ],
+                    [ 'data-bz-retained', id ],
+                    [ 'data-correctness', viewElement.getAttribute('data-correctness') || '' ]
                 ] ) );
             }
         } );
@@ -166,10 +166,10 @@ export default class ChecklistQuestionEditing extends Plugin {
 
                 return viewWriter.createEmptyElement( 'input', new Map( [
                     ...filterAllowedAttributes(modelElement.getAttributes()),
-                    ['type', 'checkbox'],
-                    ['id', id],
-                    ['data-bz-retained', id],
-                    ['data-correctness', modelElement.getAttribute('data-correctness') || '']
+                    [ 'type', 'checkbox' ],
+                    [ 'id', id ],
+                    [ 'data-bz-retained', id ],
+                    [ 'data-correctness', modelElement.getAttribute('data-correctness') || '' ]
                 ] ) );
             }
         } );
@@ -180,10 +180,10 @@ export default class ChecklistQuestionEditing extends Plugin {
 
                 return viewWriter.createEmptyElement( 'input', new Map( [
                     ...filterAllowedAttributes(modelElement.getAttributes()),
-                    ['type', 'checkbox'],
-                    ['id', id],
-                    ['data-bz-retained', id],
-                    ['data-correctness', modelElement.getAttribute('data-correctness') || '']
+                    [ 'type', 'checkbox' ],
+                    [ 'id', id ],
+                    [ 'data-bz-retained', id ],
+                    [ 'data-correctness', modelElement.getAttribute('data-correctness') || '' ]
                 ] ) );
 
                 return toWidget( input, viewWriter );

--- a/app/javascript/ckeditor/contentcommonediting.js
+++ b/app/javascript/ckeditor/contentcommonediting.js
@@ -6,6 +6,7 @@ import List from '@ckeditor/ckeditor5-list/src/list';
 import RetainedData from './retaineddata';
 import InsertTextInputCommand from './inserttextinputcommand';
 import InsertDoneButtonCommand from './insertdonebuttoncommand';
+import { ALLOWED_ATTRIBUTES, filterAllowedAttributes } from './customelementattributepreservation.js';
 
 export default class ContentCommonEditing extends Plugin {
     static get requires() {
@@ -118,31 +119,31 @@ export default class ContentCommonEditing extends Plugin {
         // Shared inputs.
         schema.register( 'textInput', {
             isObject: true,
-            allowAttributes: [ 'data-bz-retained', 'type', 'placeholder' ],
+            allowAttributes: [ 'type', 'placeholder' ].concat(ALLOWED_ATTRIBUTES),
             allowIn: [ '$root', '$block', 'tableCell' ],
         } );
 
         schema.register( 'textArea', {
             isObject: true,
-            allowAttributes: [ 'data-bz-retained', 'placeholder' ],
+            allowAttributes: [ 'placeholder' ].concat(ALLOWED_ATTRIBUTES),
             allowIn: [ '$root', '$block', 'checkboxDiv', 'radioDiv', 'tableCell', 'questionFieldset' ],
         } );
 
         schema.register( 'fileUpload', {
             isObject: true,
-            allowAttributes: [ 'class', 'data-bz-retained', 'data-bz-share-release', 'type' ],
+            allowAttributes: [ 'class', 'type' ].concat(ALLOWED_ATTRIBUTES),
             allowIn: [ '$root' ],
         } );
 
         schema.register( 'slider', {
             isObject: true,
-            allowAttributes: [ 'data-bz-answer', 'data-bz-range-answer', 'data-bz-retained', 'type', 'max', 'min', 'step' ],
+            allowAttributes: [ 'type', 'max', 'min', 'step' ].concat(ALLOWED_ATTRIBUTES),
             allowIn: [ '$root', 'questionFieldset' ],
         } );
 
         schema.register( 'select', {
             isObject: true,
-            allowAttributes: [ 'data-bz-retained', 'id', 'name' ],
+            allowAttributes: [ 'id', 'name' ].concat(ALLOWED_ATTRIBUTES),
             allowIn: [ '$root' ],
         } );
 
@@ -558,31 +559,34 @@ export default class ContentCommonEditing extends Plugin {
                 }
             },
             model: ( viewElement, modelWriter ) => {
-                return modelWriter.createElement( 'textInput', {
-                    'data-bz-retained': viewElement.getAttribute('data-bz-retained') || this._nextRetainedDataId(),
-                    'placeholder': viewElement.getAttribute('placeholder') || ''
-                } );
+                return modelWriter.createElement( 'textInput', new Map( [
+                    ...filterAllowedAttributes(viewElement.getAttributes()),
+                    ['data-bz-retained', viewElement.getAttribute('data-bz-retained') || this._nextRetainedDataId()],
+                    ['placeholder', viewElement.getAttribute('placeholder') || ''],
+                ] ) );
             }
         } );
         conversion.for( 'dataDowncast' ).elementToElement( {
             model: 'textInput',
             view: ( modelElement, viewWriter ) => {
-                const input = viewWriter.createEmptyElement( 'input', {
-                    'type': 'text',
-                    'data-bz-retained': modelElement.getAttribute('data-bz-retained') || this._nextRetainedDataId(),
-                    'placeholder': modelElement.getAttribute('placeholder') || ''
-                } );
+                const input = viewWriter.createEmptyElement( 'input', new Map( [
+                    ...filterAllowedAttributes(modelElement.getAttributes()),
+                    [ 'type', 'text' ],
+                    [ 'data-bz-retained', modelElement.getAttribute('data-bz-retained') || this._nextRetainedDataId() ],
+                    [ 'placeholder', modelElement.getAttribute('placeholder') || '' ],
+                ] ) );
                 return input;
             }
         } );
         conversion.for( 'editingDowncast' ).elementToElement( {
             model: 'textInput',
             view: ( modelElement, viewWriter ) => {
-                const input = viewWriter.createEmptyElement( 'input', {
-                    'type': 'text',
-                    'data-bz-retained': modelElement.getAttribute('data-bz-retained') || this._nextRetainedDataId(),
-                    'placeholder': modelElement.getAttribute('placeholder') || ''
-                } );
+                const input = viewWriter.createEmptyElement( 'input', new Map( [
+                    ...filterAllowedAttributes(modelElement.getAttributes()),
+                    [ 'type', 'text' ],
+                    [ 'data-bz-retained', modelElement.getAttribute('data-bz-retained') || this._nextRetainedDataId() ],
+                    [ 'placeholder', modelElement.getAttribute('placeholder') || '' ],
+                ] ) );
                 return toWidget( input, viewWriter );
             }
         } );
@@ -593,29 +597,32 @@ export default class ContentCommonEditing extends Plugin {
                 name: 'textarea',
             },
             model: ( viewElement, modelWriter ) => {
-                return modelWriter.createElement( 'textArea', {
-                    'data-bz-retained': viewElement.getAttribute('data-bz-retained') || this._nextRetainedDataId(),
-                    'placeholder': viewElement.getAttribute('placeholder') || ''
-                } );
+                return modelWriter.createElement( 'textArea', new Map( [
+                    ...filterAllowedAttributes(viewElement.getAttributes()),
+                    [ 'data-bz-retained', viewElement.getAttribute('data-bz-retained') || this._nextRetainedDataId() ],
+                    [ 'placeholder', viewElement.getAttribute('placeholder') || '' ],
+                ] ) );
             }
         } );
         conversion.for( 'dataDowncast' ).elementToElement( {
             model: 'textArea',
             view: ( modelElement, viewWriter ) => {
-                const textarea = viewWriter.createEmptyElement( 'textarea', {
-                    'data-bz-retained': modelElement.getAttribute('data-bz-retained') || this._nextRetainedDataId(),
-                    'placeholder': modelElement.getAttribute('placeholder') || ''
-                } );
+                const textarea = viewWriter.createEmptyElement( 'textarea', new Map( [
+                    ...filterAllowedAttributes(modelElement.getAttributes()),
+                    [ 'data-bz-retained', modelElement.getAttribute('data-bz-retained') || this._nextRetainedDataId() ],
+                    [ 'placeholder', modelElement.getAttribute('placeholder') || '' ],
+                ] ) );
                 return textarea;
             }
         } );
         conversion.for( 'editingDowncast' ).elementToElement( {
             model: 'textArea',
             view: ( modelElement, viewWriter ) => {
-                const textarea = viewWriter.createEmptyElement( 'textarea', {
-                    'data-bz-retained': modelElement.getAttribute('data-bz-retained') || this._nextRetainedDataId(),
-                    'placeholder': modelElement.getAttribute('placeholder') || ''
-                } );
+                const textarea = viewWriter.createEmptyElement( 'textarea', new Map( [
+                    ...filterAllowedAttributes(modelElement.getAttributes()),
+                    [ 'data-bz-retained', modelElement.getAttribute('data-bz-retained') || this._nextRetainedDataId() ],
+                    [ 'placeholder', modelElement.getAttribute('placeholder') || '' ],
+                ] ) );
                 return toWidget( textarea, viewWriter );
             }
         } );
@@ -624,44 +631,44 @@ export default class ContentCommonEditing extends Plugin {
         conversion.for( 'upcast' ).elementToElement( {
             view: {
                 name: 'input',
-                classes: [ 'bz-optional-magic-field' ],
                 attributes: {
                     'type': 'file',
                 }
             },
             model: ( viewElement, modelWriter ) => {
-                return modelWriter.createElement( 'fileUpload', {
-                    'data-bz-retained': viewElement.getAttribute('data-bz-retained') || this._nextRetainedDataId(),
-                    'data-bz-share-release': viewElement.getAttribute('data-bz-share-release') || '',
-                } );
+                return modelWriter.createElement( 'fileUpload', new Map( [
+                    ...filterAllowedAttributes(viewElement.getAttributes()),
+                    [ 'data-bz-retained': viewElement.getAttribute('data-bz-retained') || this._nextRetainedDataId() ],
+                ] ) );
             }
         } );
         conversion.for( 'dataDowncast' ).elementToElement( {
             model: 'fileUpload',
             view: ( modelElement, viewWriter ) => {
-                const input = viewWriter.createEmptyElement( 'input', {
-                    'type': 'file',
-                    'class': 'bz-optional-magic-field',
-                    'data-bz-retained': modelElement.getAttribute('data-bz-retained') || this._nextRetainedDataId(),
-                    'data-bz-share-release': modelElement.getAttribute('data-bz-share-release') || '',
-                } );
+                const input = viewWriter.createEmptyElement( 'input', new Map( [
+                    ...filterAllowedAttributes(modelElement.getAttributes()),
+                    [ 'type', 'file' ],
+                    [ 'data-bz-retained', modelElement.getAttribute('data-bz-retained') || this._nextRetainedDataId() ],
+                ] ) );
                 return input;
             }
         } );
         conversion.for( 'editingDowncast' ).elementToElement( {
             model: 'fileUpload',
             view: ( modelElement, viewWriter ) => {
-                const input = viewWriter.createEmptyElement( 'input', {
-                    'type': 'file',
-                    'class': 'bz-optional-magic-field',
-                    'data-bz-retained': modelElement.getAttribute('data-bz-retained') || this._nextRetainedDataId(),
-                    'data-bz-share-release': modelElement.getAttribute('data-bz-share-release') || '',
-                } );
+                const input = viewWriter.createEmptyElement( 'input', new Map( [
+                    ...filterAllowedAttributes(modelElement.getAttributes()),
+                    [ 'type', 'file' ],
+                    [ 'data-bz-retained', modelElement.getAttribute('data-bz-retained') || this._nextRetainedDataId() ],
+                ] ) );
                 return toWidget( input, viewWriter );
             }
         } );
 
         // <slider> converters
+        const sliderMin = 0;
+        const sliderMax = 10;
+        const sliderStep = 1;
         conversion.for( 'upcast' ).elementToElement( {
             view: {
                 name: 'input',
@@ -670,78 +677,39 @@ export default class ContentCommonEditing extends Plugin {
                 }
             },
             model: ( viewElement, modelWriter ) => {
-                let attrs = {
-                    'class': viewElement.getAttribute('class') || '',
-                    'data-bz-retained': viewElement.getAttribute('data-bz-retained') || this._nextRetainedDataId(),
-                    'min': viewElement.getAttribute('min') || 0,
-                    'max': viewElement.getAttribute('max') || 10,
-                    'step': viewElement.getAttribute('step') || 1,
-                };
-
-                // Only add these attributes if they are set.
-                const answer = viewElement.getAttribute('data-bz-answer');
-                if ( answer !== undefined ) {
-                    attrs['data-bz-answer'] = answer;
-                }
-
-                const rangeAnswer = viewElement.getAttribute('data-bz-range-answer');
-                if ( rangeAnswer !== undefined ) {
-                    attrs['data-bz-range-answer'] = rangeAnswer;
-                }
-
-                return modelWriter.createElement( 'slider', attrs );
+                return modelWriter.createElement( 'slider', new Map( [
+                    ...filterAllowedAttributes(viewElement.getAttributes()),
+                    [ 'data-bz-retained': viewElement.getAttribute('data-bz-retained') || this._nextRetainedDataId() ],
+                    [ 'min', viewElement.getAttribute('min') || sliderMin ],
+                    [ 'max', viewElement.getAttribute('max') || sliderMax ],
+                    [ 'step', viewElement.getAttribute('step') || sliderStep ],
+                ] ) );
             }
         } );
         conversion.for( 'dataDowncast' ).elementToElement( {
             model: 'slider',
             view: ( modelElement, viewWriter ) => {
-                let attrs = {
-                    'type': 'range',
-                    'class': modelElement.getAttribute('class') || '',
-                    'data-bz-retained': modelElement.getAttribute('data-bz-retained') || this._nextRetainedDataId(),
-                    'min': modelElement.getAttribute('min') || 0,
-                    'max': modelElement.getAttribute('max') || 10, 
-                    'step': modelElement.getAttribute('step') || 1,
-                };
-
-                // Only add these attributes if they are set.
-                const answer = modelElement.getAttribute('data-bz-answer');
-                if ( answer !== undefined ) {
-                    attrs['data-bz-answer'] = answer;
-                }
-
-                const rangeAnswer = modelElement.getAttribute('data-bz-range-answer');
-                if ( rangeAnswer !== undefined ) {
-                    attrs['data-bz-range-answer'] = rangeAnswer;
-                }
-
-                return viewWriter.createEmptyElement( 'input', attrs );
+                return viewWriter.createEmptyElement( 'input', new Map( [
+                    ...filterAllowedAttributes(modelElement.getAttributes()),
+                    [ 'type', 'range' ],
+                    [ 'data-bz-retained': modelElement.getAttribute('data-bz-retained') || this._nextRetainedDataId() ],
+                    [ 'min', modelElement.getAttribute('min') || sliderMin ],
+                    [ 'max', modelElement.getAttribute('max') || sliderMax ],
+                    [ 'step', modelElement.getAttribute('step') || sliderStep ],
+                ] ) );
             }
         } );
         conversion.for( 'editingDowncast' ).elementToElement( {
             model: 'slider',
             view: ( modelElement, viewWriter ) => {
-                let attrs = {
-                    'type': 'range',
-                    'class': modelElement.getAttribute('class') || '',
-                    'data-bz-retained': modelElement.getAttribute('data-bz-retained') || this._nextRetainedDataId(),
-                    'min': modelElement.getAttribute('min') || 0,
-                    'max': modelElement.getAttribute('max') || 10,
-                    'step': modelElement.getAttribute('step') || 1,
-                };
-
-                // Only add these attributes if they are set.
-                const answer = modelElement.getAttribute('data-bz-answer');
-                if ( answer !== undefined ) {
-                    attrs['data-bz-answer'] = answer;
-                }
-
-                const rangeAnswer = modelElement.getAttribute('data-bz-range-answer');
-                if ( rangeAnswer !== undefined ) {
-                    attrs['data-bz-range-answer'] = rangeAnswer;
-                }
-
-                const input = viewWriter.createEmptyElement( 'input', attrs );
+                const input = viewWriter.createEmptyElement( 'input', new Map( [
+                    ...filterAllowedAttributes(modelElement.getAttributes()),
+                    [ 'type', 'range' ],
+                    [ 'data-bz-retained': modelElement.getAttribute('data-bz-retained') || this._nextRetainedDataId() ],
+                    [ 'min', modelElement.getAttribute('min') || sliderMin ],
+                    [ 'max', modelElement.getAttribute('max') || sliderMax ],
+                    [ 'step', modelElement.getAttribute('step') || sliderStep ],
+                ] ) );
                 return toWidget( input, viewWriter );
             }
         } );
@@ -752,32 +720,35 @@ export default class ContentCommonEditing extends Plugin {
                 name: 'select',
             },
             model: ( viewElement, modelWriter ) => {
-                return modelWriter.createElement( 'select', {
-                    'data-bz-retained': viewElement.getAttribute('data-bz-retained') || this._nextRetainedDataId(),
-                    'name': viewElement.getAttribute('name'),
-                    'id': viewElement.getAttribute('id')
-                } );
+                return modelWriter.createElement( 'select', new Map( [
+                    ...filterAllowedAttributes(viewElement.getAttributes()),
+                    [ 'data-bz-retained', viewElement.getAttribute('data-bz-retained') || this._nextRetainedDataId() ],
+                    [ 'name', viewElement.getAttribute('name') ],
+                    [ 'id', viewElement.getAttribute('id') ],
+                ] ) );
             }
         } );
         conversion.for( 'dataDowncast' ).elementToElement( {
             model: 'select',
             view: ( modelElement, viewWriter ) => {
-                const select = viewWriter.createContainerElement( 'select', {
-                    'data-bz-retained': modelElement.getAttribute('data-bz-retained') || this._nextRetainedDataId(),
-                    'name': modelElement.getAttribute('name'),
-                    'id': modelElement.getAttribute('id'),
-                } );
+                const select = viewWriter.createContainerElement( 'select', new Map( [
+                    ...filterAllowedAttributes(modelElement.getAttributes()),
+                    [ 'data-bz-retained', modelElement.getAttribute('data-bz-retained') || this._nextRetainedDataId() ],
+                    [ 'name', modelElement.getAttribute('name') ],
+                    [ 'id', modelElement.getAttribute('id') ],
+                ] ) );
                 return select;
             }
         } );
         conversion.for( 'editingDowncast' ).elementToElement( {
             model: 'select',
             view: ( modelElement, viewWriter ) => {
-                const select = viewWriter.createContainerElement( 'select', {
-                    'data-bz-retained': modelElement.getAttribute('data-bz-retained') || this._nextRetainedDataId(),
-                    'name': modelElement.getAttribute('name'),
-                    'id': modelElement.getAttribute('id')
-                } );
+                const select = viewWriter.createContainerElement( 'select', new Map( [
+                    ...filterAllowedAttributes(modelElement.getAttributes()),
+                    [ 'data-bz-retained', modelElement.getAttribute('data-bz-retained') || this._nextRetainedDataId() ],
+                    [ 'name', modelElement.getAttribute('name') ],
+                    [ 'id', modelElement.getAttribute('id') ],
+                ] ) );
                 return toWidget( select, viewWriter );
             }
         } );

--- a/app/javascript/ckeditor/contentcommonediting.js
+++ b/app/javascript/ckeditor/contentcommonediting.js
@@ -638,7 +638,7 @@ export default class ContentCommonEditing extends Plugin {
             model: ( viewElement, modelWriter ) => {
                 return modelWriter.createElement( 'fileUpload', new Map( [
                     ...filterAllowedAttributes(viewElement.getAttributes()),
-                    [ 'data-bz-retained': viewElement.getAttribute('data-bz-retained') || this._nextRetainedDataId() ],
+                    [ 'data-bz-retained', viewElement.getAttribute('data-bz-retained') || this._nextRetainedDataId() ],
                 ] ) );
             }
         } );
@@ -679,7 +679,7 @@ export default class ContentCommonEditing extends Plugin {
             model: ( viewElement, modelWriter ) => {
                 return modelWriter.createElement( 'slider', new Map( [
                     ...filterAllowedAttributes(viewElement.getAttributes()),
-                    [ 'data-bz-retained': viewElement.getAttribute('data-bz-retained') || this._nextRetainedDataId() ],
+                    [ 'data-bz-retained', viewElement.getAttribute('data-bz-retained') || this._nextRetainedDataId() ],
                     [ 'min', viewElement.getAttribute('min') || sliderMin ],
                     [ 'max', viewElement.getAttribute('max') || sliderMax ],
                     [ 'step', viewElement.getAttribute('step') || sliderStep ],
@@ -692,7 +692,7 @@ export default class ContentCommonEditing extends Plugin {
                 return viewWriter.createEmptyElement( 'input', new Map( [
                     ...filterAllowedAttributes(modelElement.getAttributes()),
                     [ 'type', 'range' ],
-                    [ 'data-bz-retained': modelElement.getAttribute('data-bz-retained') || this._nextRetainedDataId() ],
+                    [ 'data-bz-retained', modelElement.getAttribute('data-bz-retained') || this._nextRetainedDataId() ],
                     [ 'min', modelElement.getAttribute('min') || sliderMin ],
                     [ 'max', modelElement.getAttribute('max') || sliderMax ],
                     [ 'step', modelElement.getAttribute('step') || sliderStep ],
@@ -705,7 +705,7 @@ export default class ContentCommonEditing extends Plugin {
                 const input = viewWriter.createEmptyElement( 'input', new Map( [
                     ...filterAllowedAttributes(modelElement.getAttributes()),
                     [ 'type', 'range' ],
-                    [ 'data-bz-retained': modelElement.getAttribute('data-bz-retained') || this._nextRetainedDataId() ],
+                    [ 'data-bz-retained', modelElement.getAttribute('data-bz-retained') || this._nextRetainedDataId() ],
                     [ 'min', modelElement.getAttribute('min') || sliderMin ],
                     [ 'max', modelElement.getAttribute('max') || sliderMax ],
                     [ 'step', modelElement.getAttribute('step') || sliderStep ],

--- a/app/javascript/ckeditor/contentcommonediting.js
+++ b/app/javascript/ckeditor/contentcommonediting.js
@@ -381,21 +381,32 @@ export default class ContentCommonEditing extends Plugin {
 
         // <questionFieldset> converters
         conversion.for( 'upcast' ).elementToElement( {
-            model: 'questionFieldset',
             view: {
                 name: 'fieldset'
+            },
+            model: ( viewElement, modelWriter ) => {
+                // Only include the class attribute if it's set.
+                const classes = viewElement.getAttribute('class');
+                const attrs = classes ? { 'class': classes } : {};
+                return modelWriter.createElement( 'questionFieldset', attrs );
             }
         } );
         conversion.for( 'dataDowncast' ).elementToElement( {
             model: 'questionFieldset',
-            view: {
-                name: 'fieldset'
+            view: ( modelElement, viewWriter ) => {
+                // Only include the class attribute if it's set.
+                const classes = modelElement.getAttribute('class');
+                const attrs = classes ? { 'class': classes } : {};
+                return viewWriter.createEditableElement( 'fieldset', attrs );
             }
         } );
         conversion.for( 'editingDowncast' ).elementToElement( {
             model: 'questionFieldset',
             view: ( modelElement, viewWriter ) => {
-                return viewWriter.createContainerElement( 'fieldset' );
+                // Only include the class attribute if it's set.
+                const classes = modelElement.getAttribute('class');
+                const attrs = classes ? { 'class': classes } : {};
+                return viewWriter.createContainerElement( 'fieldset', attrs );
             }
         } );
 
@@ -790,6 +801,7 @@ export default class ContentCommonEditing extends Plugin {
             },
             model: ( viewElement, modelWriter ) => {
                 return modelWriter.createElement( 'heading6', {
+                    'class': viewElement.getAttribute('class'),
                     'id': viewElement.getAttribute('id'),
                 } );
             }
@@ -798,6 +810,7 @@ export default class ContentCommonEditing extends Plugin {
             model: 'heading6',
             view: ( modelElement, viewWriter ) => {
                 return viewWriter.createEditableElement( 'h6', {
+                    'class': modelElement.getAttribute('class'),
                     'id': modelElement.getAttribute( 'id' ),
                 } );
             }
@@ -806,6 +819,7 @@ export default class ContentCommonEditing extends Plugin {
             model: 'heading6',
             view: ( modelElement, viewWriter ) => {
                 return viewWriter.createEditableElement( 'h6', {
+                    'class': modelElement.getAttribute('class'),
                     'id': modelElement.getAttribute( 'id' ),
                 } );
             }

--- a/app/javascript/ckeditor/radioquestionediting.js
+++ b/app/javascript/ckeditor/radioquestionediting.js
@@ -174,10 +174,10 @@ export default class RadioQuestionEditing extends Plugin {
 
                 return modelWriter.createElement( 'radioInput', new Map( [
                     ...filterAllowedAttributes(viewElement.getAttributes()),
-                    ['id', id],
-                    ['name', radioGroupName],
-                    ['data-bz-retained', id],
-                    ['data-correctness', viewElement.getAttribute('data-correctness') || '']
+                    [ 'id', id ],
+                    [ 'name', radioGroupName ],
+                    [ 'data-bz-retained', id ],
+                    [ 'data-correctness', viewElement.getAttribute('data-correctness') || '' ]
                 ] ) );
             }
 
@@ -207,11 +207,11 @@ export default class RadioQuestionEditing extends Plugin {
 
                 return viewWriter.createEmptyElement( 'input', new Map( [
                     ...filterAllowedAttributes(modelElement.getAttributes()),
-                    ['type', 'radio'],
-                    ['id', id],
-                    ['name', radioGroupName],
-                    ['data-bz-retained', id],
-                    ['data-correctness', modelElement.getAttribute('data-correctness') || '']
+                    [ 'type', 'radio' ],
+                    [ 'id', id ],
+                    [ 'name', radioGroupName ],
+                    [ 'data-bz-retained', id ],
+                    [ 'data-correctness', modelElement.getAttribute('data-correctness') || '' ]
                 ] ) );
             }
         } );
@@ -240,11 +240,11 @@ export default class RadioQuestionEditing extends Plugin {
 
                 return viewWriter.createEmptyElement( 'input', new Map( [
                     ...filterAllowedAttributes(modelElement.getAttributes()),
-                    ['type', 'radio'],
-                    ['id', id],
-                    ['name', radioGroupName],
-                    ['data-bz-retained', id],
-                    ['data-correctness', modelElement.getAttribute('data-correctness') || '']
+                    [ 'type', 'radio' ],
+                    [ 'id', id ],
+                    [ 'name', radioGroupName ],
+                    [ 'data-bz-retained', id ],
+                    [ 'data-correctness', modelElement.getAttribute('data-correctness') || '' ]
                 ] ) );
                 return toWidget( input, viewWriter );
             }

--- a/app/javascript/ckeditor/tablecontentediting.js
+++ b/app/javascript/ckeditor/tablecontentediting.js
@@ -26,6 +26,10 @@ export default class TableContentEditing extends Plugin {
         schema.extend( 'slider', {
             allowIn: 'tableCell'
         } );
+
+        schema.extend( 'heading6', {
+            allowIn: 'tableCell'
+        } );
     }
 
     _defineConverters() {


### PR DESCRIPTION
Extends the work from #121 to cover all other input types. (Sliders, textareas, text inputs, file uploads, dropdowns.)