### PR TITLE
Allow h6 in table cells

### DIFF
--- a/app/javascript/ckeditor/contentcommonediting.js
+++ b/app/javascript/ckeditor/contentcommonediting.js
@@ -381,21 +381,32 @@ export default class ContentCommonEditing extends Plugin {
 
         // <questionFieldset> converters
         conversion.for( 'upcast' ).elementToElement( {
-            model: 'questionFieldset',
             view: {
                 name: 'fieldset'
+            },
+            model: ( viewElement, modelWriter ) => {
+                // Only include the class attribute if it's set.
+                const classes = viewElement.getAttribute('class');
+                const attrs = classes ? { 'class': classes } : {};
+                return modelWriter.createElement( 'questionFieldset', attrs );
             }
         } );
         conversion.for( 'dataDowncast' ).elementToElement( {
             model: 'questionFieldset',
-            view: {
-                name: 'fieldset'
+            view: ( modelElement, viewWriter ) => {
+                // Only include the class attribute if it's set.
+                const classes = modelElement.getAttribute('class');
+                const attrs = classes ? { 'class': classes } : {};
+                return viewWriter.createEditableElement( 'fieldset', attrs );
             }
         } );
         conversion.for( 'editingDowncast' ).elementToElement( {
             model: 'questionFieldset',
             view: ( modelElement, viewWriter ) => {
-                return viewWriter.createContainerElement( 'fieldset' );
+                // Only include the class attribute if it's set.
+                const classes = modelElement.getAttribute('class');
+                const attrs = classes ? { 'class': classes } : {};
+                return viewWriter.createContainerElement( 'fieldset', attrs );
             }
         } );
 
@@ -790,6 +801,7 @@ export default class ContentCommonEditing extends Plugin {
             },
             model: ( viewElement, modelWriter ) => {
                 return modelWriter.createElement( 'heading6', {
+                    'class': viewElement.getAttribute('class'),
                     'id': viewElement.getAttribute('id'),
                 } );
             }
@@ -798,6 +810,7 @@ export default class ContentCommonEditing extends Plugin {
             model: 'heading6',
             view: ( modelElement, viewWriter ) => {
                 return viewWriter.createEditableElement( 'h6', {
+                    'class': modelElement.getAttribute('class'),
                     'id': modelElement.getAttribute( 'id' ),
                 } );
             }
@@ -806,6 +819,7 @@ export default class ContentCommonEditing extends Plugin {
             model: 'heading6',
             view: ( modelElement, viewWriter ) => {
                 return viewWriter.createEditableElement( 'h6', {
+                    'class': modelElement.getAttribute('class'),
                     'id': modelElement.getAttribute( 'id' ),
                 } );
             }

--- a/app/javascript/ckeditor/tablecontentediting.js
+++ b/app/javascript/ckeditor/tablecontentediting.js
@@ -26,6 +26,10 @@ export default class TableContentEditing extends Plugin {
         schema.extend( 'slider', {
             allowIn: 'tableCell'
         } );
+
+        schema.extend( 'heading6', {
+            allowIn: 'tableCell'
+        } );
     }
 
     _defineConverters() {


### PR DESCRIPTION
Task: https://app.asana.com/0/0/1165367656314881/f

Small change, but we use this in module 1.

Before: 
<img width="675" alt="Screen Shot 2020-03-18 at 2 48 07 PM" src="https://user-images.githubusercontent.com/1382374/77001181-81c47b80-6927-11ea-981b-3044b117f3d0.png">

After:
<img width="675" alt="Screen Shot 2020-03-18 at 2 44 15 PM" src="https://user-images.githubusercontent.com/1382374/77001195-86892f80-6927-11ea-868f-0892bbb94d78.png">
