### PR TITLE
Allow classes on fieldsets

### DIFF
--- a/app/javascript/ckeditor/contentcommonediting.js
+++ b/app/javascript/ckeditor/contentcommonediting.js
@@ -381,21 +381,32 @@ export default class ContentCommonEditing extends Plugin {
 
         // <questionFieldset> converters
         conversion.for( 'upcast' ).elementToElement( {
-            model: 'questionFieldset',
             view: {
                 name: 'fieldset'
+            },
+            model: ( viewElement, modelWriter ) => {
+                // Only include the class attribute if it's set.
+                const classes = viewElement.getAttribute('class');
+                const attrs = classes ? { 'class': classes } : {};
+                return modelWriter.createElement( 'questionFieldset', attrs );
             }
         } );
         conversion.for( 'dataDowncast' ).elementToElement( {
             model: 'questionFieldset',
-            view: {
-                name: 'fieldset'
+            view: ( modelElement, viewWriter ) => {
+                // Only include the class attribute if it's set.
+                const classes = modelElement.getAttribute('class');
+                const attrs = classes ? { 'class': classes } : {};
+                return viewWriter.createEditableElement( 'fieldset', attrs );
             }
         } );
         conversion.for( 'editingDowncast' ).elementToElement( {
             model: 'questionFieldset',
             view: ( modelElement, viewWriter ) => {
-                return viewWriter.createContainerElement( 'fieldset' );
+                // Only include the class attribute if it's set.
+                const classes = modelElement.getAttribute('class');
+                const attrs = classes ? { 'class': classes } : {};
+                return viewWriter.createContainerElement( 'fieldset', attrs );
             }
         } );
 


### PR DESCRIPTION
Purpose: We need the "dont-mix" class on the fieldset element for checklists/radios/matching games where we don't want the JS to shuffle the options.

Task: https://app.asana.com/0/0/1166022624267523/f