### PR TITLE
Allow classes on h6

### DIFF
--- a/app/javascript/ckeditor/contentcommonediting.js
+++ b/app/javascript/ckeditor/contentcommonediting.js
@@ -801,6 +801,7 @@ export default class ContentCommonEditing extends Plugin {
             },
             model: ( viewElement, modelWriter ) => {
                 return modelWriter.createElement( 'heading6', {
+                    'class': viewElement.getAttribute('class'),
                     'id': viewElement.getAttribute('id'),
                 } );
             }
@@ -809,6 +810,7 @@ export default class ContentCommonEditing extends Plugin {
             model: 'heading6',
             view: ( modelElement, viewWriter ) => {
                 return viewWriter.createEditableElement( 'h6', {
+                    'class': modelElement.getAttribute('class'),
                     'id': modelElement.getAttribute( 'id' ),
                 } );
             }
@@ -817,6 +819,7 @@ export default class ContentCommonEditing extends Plugin {
             model: 'heading6',
             view: ( modelElement, viewWriter ) => {
                 return viewWriter.createEditableElement( 'h6', {
+                    'class': modelElement.getAttribute('class'),
                     'id': modelElement.getAttribute( 'id' ),
                 } );
             }


### PR DESCRIPTION
Purpose: We need `<h6 class="bz-graded-question"></h6>` in question bodies to show the mastery question "icon".

Task: https://app.asana.com/0/0/1166022624267526/f

In action:

<img width="675" alt="Screen Shot 2020-03-18 at 2 45 44 PM" src="https://user-images.githubusercontent.com/1382374/77001098-5e013580-6927-11ea-822d-b56d007e1463.png">
