### PR TITLE
Fix an annoying editor crash

### DIFF
--- a/app/javascript/ckeditor/utils.js
+++ b/app/javascript/ckeditor/utils.js
@@ -20,5 +20,5 @@ export function preventCKEditorHandling( domElement, editor ) {
 // name ancestorName. If there are multiple matching elements, return only the
 // topmost one.
 export function getNamedAncestor( ancestorName, modelElement ) {
-    return modelElement.getAncestors().filter( x => { return x.name == 'question' } )[0];
+    return modelElement.getAncestors().filter( x => { return x.name == ancestorName } )[0];
 }

--- a/app/javascript/components/ContentEditor.js
+++ b/app/javascript/components/ContentEditor.js
@@ -476,6 +476,13 @@ class ContentEditor extends Component {
                                 } else if ( ['question'].includes( modelElement ) ) {
                                     const questionElem = getNamedAncestor( 'question', this.state['selectedElement'] );
 
+                                    if (questionElem === undefined) {
+                                        // The selected element no longer has 'question' as an ancestor - it was
+                                        // probably deleted. We can just return and let React re-render with the new
+                                        // selection.
+                                        return;
+                                    }
+
                                     return (
                                         <>
                                             <h4>Question</h4>


### PR DESCRIPTION
See code comments for more details. Also fixes a hardcoded name in a utility function 🤦‍♀.

Test steps:

* Load onboard to braven in the editor.
* Scroll to the bottom and find the matrix under "Big Rock 2".
* Click the table handle
* Press delete
* If the entire editor disappears, you've repro'd the bug. If not, the bug is fixed!

<img width="561" alt="Screen Shot 2020-03-19 at 2 20 15 PM" src="https://user-images.githubusercontent.com/1382374/77106303-db42ae00-69ec-11ea-9a34-d74f62c5fc28.png">
 
Task: https://app.asana.com/0/1142638035116665/1166022624267529/f