### PR TITLE
Allow IDs in headings; style heading dropdown

### DIFF
--- a/app/assets/stylesheets/course_contents.scss
+++ b/app/assets/stylesheets/course_contents.scss
@@ -42,6 +42,11 @@ body {
 .bz-module h4,
 .bz-module h5,
 .bz-module h6,
+button.ck.ck-button.ck-heading_h2 .ck-button__label,
+button.ck.ck-button.ck-heading_h3 .ck-button__label,
+button.ck.ck-button.ck-heading_h4 .ck-button__label,
+button.ck.ck-button.ck-heading_h5 .ck-button__label,
+button.ck.ck-button.ck-heading_h6 .ck-button__label,
 .bz-module nav li,
 .bz-module input[type="button"],
 .bz-module th {
@@ -49,6 +54,33 @@ body {
 	text-transform: uppercase;
 	line-height: normal;
 	font-weight: normal;
+}
+
+button.ck.ck-button.ck-heading_h2 .ck-button__label,
+button.ck.ck-button.ck-heading_h4 .ck-button__label,
+button.ck.ck-button.ck-heading_h6 .ck-button__label {
+	color: #EB3B46;
+}
+
+button.ck.ck-button.ck-heading_h2 .ck-button__label {
+	font-size: 40px;
+}
+
+button.ck.ck-button.ck-heading_h3 .ck-button__label {
+	font-size: 34px;
+}
+
+button.ck.ck-button.ck-heading_h4 .ck-button__label {
+	font-size: 27px;
+}
+
+button.ck.ck-button.ck-heading_h6 .ck-button__label {
+ font-size: 16px;
+ letter-spacing: 0.1em;
+}
+
+button.ck.ck-button.ck-heading_h5 .ck-button__label {
+	font-size: 24px;
 }
 
 /* Unhide "display: none" things. */
@@ -85,8 +117,6 @@ div.content > blockquote:focus > small {
         color: black;
         background: none;
 }
-
-
 
 /* --- Right sidebar styles --- */
 ul.widget-list li.disabled,

--- a/app/javascript/ckeditor/contentcommonediting.js
+++ b/app/javascript/ckeditor/contentcommonediting.js
@@ -153,12 +153,6 @@ export default class ContentCommonEditing extends Plugin {
             allowIn: [ 'select' ],
             allowContentOf: '$block'
         } );
-
-        schema.register( 'heading6', {
-            allowAttributes: [ 'id' ],
-            allowIn: [ '$root' ],
-            allowContentOf: [ '$block' ],
-        });
     }
 
     _defineConverters() {
@@ -197,7 +191,10 @@ export default class ContentCommonEditing extends Plugin {
                 return modelWriter.createElement( 'contentTitle', {
                     'id': viewElement.getAttribute('id'),
                 } );
-            }
+            },
+            // Use high priority to overwrite heading converters defined in
+            // customelementattributepreservation.js.
+            converterPriority: 'high'
         } );
         conversion.for( 'dataDowncast' ).elementToElement( {
             model: 'contentTitle',
@@ -205,7 +202,10 @@ export default class ContentCommonEditing extends Plugin {
                 return viewWriter.createEditableElement( 'h5', {
                     'id': modelElement.getAttribute( 'id' ),
                 } );
-            }
+            },
+            // Use high priority to overwrite heading converters defined in
+            // customelementattributepreservation.js.
+            converterPriority: 'high'
         } );
         conversion.for( 'editingDowncast' ).elementToElement( {
             model: 'contentTitle',
@@ -221,7 +221,10 @@ export default class ContentCommonEditing extends Plugin {
                 } );
 
                 return toWidgetEditable( h5, viewWriter );
-            }
+            },
+            // Use high priority to overwrite heading converters defined in
+            // customelementattributepreservation.js.
+            converterPriority: 'high'
         } );
 
         // <contentBody> converters
@@ -303,7 +306,10 @@ export default class ContentCommonEditing extends Plugin {
                 return modelWriter.createElement( 'questionTitle', {
                     'id': viewElement.getAttribute('id'),
                 } );
-            }
+            },
+            // Use high priority to overwrite heading converters defined in
+            // customelementattributepreservation.js.
+            converterPriority: 'high'
         } );
         conversion.for( 'dataDowncast' ).elementToElement( {
             model: 'questionTitle',
@@ -311,7 +317,10 @@ export default class ContentCommonEditing extends Plugin {
                 return viewWriter.createEditableElement( 'h5', {
                     'id': modelElement.getAttribute( 'id' ),
                 } );
-            }
+            },
+            // Use high priority to overwrite heading converters defined in
+            // customelementattributepreservation.js.
+            converterPriority: 'high'
         } );
         conversion.for( 'editingDowncast' ).elementToElement( {
             model: 'questionTitle',
@@ -327,7 +336,10 @@ export default class ContentCommonEditing extends Plugin {
                 } );
 
                 return toWidgetEditable( h5, viewWriter );
-            }
+            },
+            // Use high priority to overwrite heading converters defined in
+            // customelementattributepreservation.js.
+            converterPriority: 'high'
         } );
 
         // <questionBody> converters
@@ -335,7 +347,7 @@ export default class ContentCommonEditing extends Plugin {
             model: 'questionBody',
             view: {
                 name: 'div'
-            }
+            },
         } );
         conversion.for( 'dataDowncast' ).elementToElement( {
             model: 'questionBody',
@@ -507,13 +519,19 @@ export default class ContentCommonEditing extends Plugin {
             model: 'answerTitle',
             view: {
                 name: 'h5'
-            }
+            },
+            // Use high priority to overwrite heading converters defined in
+            // customelementattributepreservation.js.
+            converterPriority: 'high'
         } );
         conversion.for( 'dataDowncast' ).elementToElement( {
             model: 'answerTitle',
             view: {
                 name: 'h5'
-            }
+            },
+            // Use high priority to overwrite heading converters defined in
+            // customelementattributepreservation.js.
+            converterPriority: 'high'
         } );
         conversion.for( 'editingDowncast' ).elementToElement( {
             model: 'answerTitle',
@@ -527,7 +545,10 @@ export default class ContentCommonEditing extends Plugin {
                 } );
 
                 return h5;
-            }
+            },
+            // Use high priority to overwrite heading converters defined in
+            // customelementattributepreservation.js.
+            converterPriority: 'high'
         } );
 
         // <answerText> converters
@@ -791,37 +812,6 @@ export default class ContentCommonEditing extends Plugin {
                     'value': modelElement.getAttribute('value'),
                 } );
                 return toWidget( option, viewWriter );
-            }
-        } );
-
-        // <heading6> converters
-        conversion.for( 'upcast' ).elementToElement( {
-            view: {
-                name: 'h6'
-            },
-            model: ( viewElement, modelWriter ) => {
-                return modelWriter.createElement( 'heading6', {
-                    'class': viewElement.getAttribute('class'),
-                    'id': viewElement.getAttribute('id'),
-                } );
-            }
-        } );
-        conversion.for( 'dataDowncast' ).elementToElement( {
-            model: 'heading6',
-            view: ( modelElement, viewWriter ) => {
-                return viewWriter.createEditableElement( 'h6', {
-                    'class': modelElement.getAttribute('class'),
-                    'id': modelElement.getAttribute( 'id' ),
-                } );
-            }
-        } );
-        conversion.for( 'editingDowncast' ).elementToElement( {
-            model: 'heading6',
-            view: ( modelElement, viewWriter ) => {
-                return viewWriter.createEditableElement( 'h6', {
-                    'class': modelElement.getAttribute('class'),
-                    'id': modelElement.getAttribute( 'id' ),
-                } );
             }
         } );
     }

--- a/app/javascript/ckeditor/tablecontentediting.js
+++ b/app/javascript/ckeditor/tablecontentediting.js
@@ -26,10 +26,6 @@ export default class TableContentEditing extends Plugin {
         schema.extend( 'slider', {
             allowIn: 'tableCell'
         } );
-
-        schema.extend( 'heading6', {
-            allowIn: 'tableCell'
-        } );
     }
 
     _defineConverters() {

--- a/app/javascript/components/ContentEditor.js
+++ b/app/javascript/components/ContentEditor.js
@@ -164,6 +164,16 @@ BalloonEditor.defaultConfig = {
             'mergeTableCells'
         ]
     },
+    heading: {
+        options: [
+            { model: 'paragraph', title: 'Paragraph', class: 'ck-heading_paragraph' },
+            { model: 'heading1', view: 'h2', title: 'Heading 1', class: 'ck-heading_h2' },
+            { model: 'heading2', view: 'h3', title: 'Heading 2', class: 'ck-heading_h3' },
+            { model: 'heading3', view: 'h4', title: 'Heading 3', class: 'ck-heading_h4' },
+            { model: 'heading4', view: 'h5', title: 'Heading 4', class: 'ck-heading_h5' },
+            { model: 'heading5', view: 'h6', title: 'Heading 5', class: 'ck-heading_h6' },
+        ]
+    },
     simpleUpload: {
         // The URL that the images are uploaded to.
         uploadUrl: '/image_upload_api',


### PR DESCRIPTION
This PR:

* Allows `id` attributes (and other custom attributes) on headings
* Adds support for `h5`s in the document root
* Refactors h6 support
* Refactors custom element attribute preservation slightly
* Adds UI support for all heading types
* Fixes UI dropdown styling for heading elements in the editor

<img width="232" alt="Screen Shot 2020-03-26 at 4 39 06 PM" src="https://user-images.githubusercontent.com/1382374/77699388-57ef0280-6f80-11ea-97e6-f31268857cb8.png">

Task: https://app.asana.com/0/1142638035116665/1160411399917403/f