### PR TITLE
Fix correctness chooser

### DIFF
--- a/app/javascript/ckeditor/checklistquestionediting.js
+++ b/app/javascript/ckeditor/checklistquestionediting.js
@@ -183,10 +183,11 @@ export default class ChecklistQuestionEditing extends Plugin {
                     [ 'type', 'checkbox' ],
                     [ 'id', id ],
                     [ 'data-bz-retained', id ],
-                    [ 'data-correctness', modelElement.getAttribute('data-correctness') || '' ]
+                    [ 'data-correctness', modelElement.getAttribute('data-correctness') || '' ],
+                    [ 'disabled', 'disabled' ],
                 ] ) );
 
-                return toWidget( input, viewWriter );
+                return input;
             }
         } );
 

--- a/app/javascript/ckeditor/utils.js
+++ b/app/javascript/ckeditor/utils.js
@@ -22,3 +22,23 @@ export function preventCKEditorHandling( domElement, editor ) {
 export function getNamedAncestor( ancestorName, modelElement ) {
     return modelElement.getAncestors().filter( x => { return x.name == ancestorName } )[0];
 }
+
+// Return the model element that is a child or sibling of modelElement, with the model
+// name ancestorName. Returns the first result in order of:
+// * Children, in DOM order
+// * Siblings, in DOM order
+// * undefined
+export function getNamedChildOrSibling( elementName, modelElement ) {
+    function filterByName( elementName, modelElement ) {
+        return Array.from(modelElement.getChildren()).filter(
+                x => { return x.name == elementName }
+        )[0];
+    }
+
+    let firstMatch;
+    if ( firstMatch = filterByName( elementName, modelElement ) ) {
+        return firstMatch;
+    }
+
+    return filterByName( elementName, modelElement.parent );
+}

--- a/app/javascript/components/ContentEditor.js
+++ b/app/javascript/components/ContentEditor.js
@@ -63,7 +63,7 @@ import ContentPartList from './ContentPartList';
 import ContentPartPreview from './ContentPartPreview';
 
 // Other local imports.
-import { getNamedAncestor } from '../ckeditor/utils';
+import { getNamedAncestor, getNamedChildOrSibling } from '../ckeditor/utils';
 
 // Plugins to include in the build.
 BalloonEditor.builtinPlugins = [
@@ -464,15 +464,21 @@ class ContentEditor extends Component {
                                             <label htmlFor='input-answer'>Correct Answer</label>
                                         </>
                                     );
-                                } else if ( ['checkboxInput', 'radioInput'].includes( modelElement ) ) {
+                                } else if ( ['checkboxDiv', 'radioDiv'].includes( modelElement ) ) {
+                                    const inputTypes = {
+                                        'checkboxDiv': 'checkboxInput',
+                                        'radioDiv': 'radioInput',
+                                    }
+                                    const inputElement = getNamedChildOrSibling( inputTypes[modelElement], this.state['selectedElement'] );
+
                                     return (
                                         <>
                                             <h4>Option</h4>
                                             <select
                                                 id='input-correctness'
-                                                defaultValue={this.state['selectedElement'].getAttribute('data-correctness')}
+                                                defaultValue={inputElement.getAttribute('data-correctness')}
                                                 onChange={( evt ) => {
-                                                    this.editor.execute( 'setAttributes', { 'data-correctness': evt.target.value } );
+                                                    this.editor.execute( 'setAttributes', { 'data-correctness': evt.target.value }, inputElement );
                                                 }}
                                             >
                                                 <option value="">CHOOSE ONE</option>


### PR DESCRIPTION
Bugfix: Correctness dropdown wasn't showing up at all, now shows up correctly.

Enhancement: Correctness dropdown now works when the current selection is checkbox/radio inputs, labels, OR parent divs, and updates the data-correctness attribute of the input accordingly.

Screenshot:

<img width="1145" alt="Screen Shot 2020-03-31 at 12 18 36 PM" src="https://user-images.githubusercontent.com/1382374/78055852-c4378080-7349-11ea-9d59-523698096640.png">

Task: https://app.asana.com/0/1142638035116665/1168290061278555/f

NB: Updating the correctness does not currently update the edit view ([bug](https://app.asana.com/0/1142638035116665/1169209719391233/f)). Relying on checkboxDiv / radioDiv means you won't be able to edit correctness in matrices; I think this is acceptable behavior at the moment since we shouldn't be creating new matrices, but it's something we could add in the future if we need to.