### PR TITLE
Add value attribute handling to radio inputs

### DIFF
--- a/app/javascript/ckeditor/radioquestionediting.js
+++ b/app/javascript/ckeditor/radioquestionediting.js
@@ -176,6 +176,7 @@ export default class RadioQuestionEditing extends Plugin {
                     ...filterAllowedAttributes(viewElement.getAttributes()),
                     [ 'id', id ],
                     [ 'name', radioGroupName ],
+                    [ 'value', viewElement.getAttribute('value') ],
                     [ 'data-bz-retained', id ],
                     [ 'data-correctness', viewElement.getAttribute('data-correctness') || '' ]
                 ] ) );
@@ -210,6 +211,7 @@ export default class RadioQuestionEditing extends Plugin {
                     [ 'type', 'radio' ],
                     [ 'id', id ],
                     [ 'name', radioGroupName ],
+                    [ 'value', modelElement.getAttribute('value') ],
                     [ 'data-bz-retained', id ],
                     [ 'data-correctness', modelElement.getAttribute('data-correctness') || '' ]
                 ] ) );
@@ -243,6 +245,7 @@ export default class RadioQuestionEditing extends Plugin {
                     [ 'type', 'radio' ],
                     [ 'id', id ],
                     [ 'name', radioGroupName ],
+                    [ 'value', modelElement.getAttribute('value') ],
                     [ 'data-bz-retained', id ],
                     [ 'data-correctness', modelElement.getAttribute('data-correctness') || '' ]
                 ] ) );


### PR DESCRIPTION
Task: https://app.asana.com/0/1142638035116665/1169229931357115/f

(Not much to review here, just informational PR.)

NB: We'll need something at some point that automatically chooses values for radio inputs ([feature](https://app.asana.com/0/0/1169229931357127/f)). In the mean time, new radio values will all default to 'undefined'.