### PR TITLE
Add an insert-text-block button

### DIFF
--- a/app/javascript/ckeditor/contentcommonediting.js
+++ b/app/javascript/ckeditor/contentcommonediting.js
@@ -6,6 +6,7 @@ import List from '@ckeditor/ckeditor5-list/src/list';
 import RetainedData from './retaineddata';
 import InsertTextInputCommand from './inserttextinputcommand';
 import InsertDoneButtonCommand from './insertdonebuttoncommand';
+import InsertContentBlockCommand from './insertcontentblockcommand';
 import { ALLOWED_ATTRIBUTES, filterAllowedAttributes } from './customelementattributepreservation.js';
 
 export default class ContentCommonEditing extends Plugin {
@@ -19,6 +20,7 @@ export default class ContentCommonEditing extends Plugin {
 
         this.editor.commands.add( 'insertTextInput', new InsertTextInputCommand( this.editor ) );
         this.editor.commands.add( 'insertDoneButton', new InsertDoneButtonCommand( this.editor ) );
+        this.editor.commands.add( 'insertContentBlock', new InsertContentBlockCommand( this.editor ) );
 
         // Add a shortcut to the retained data ID function.
         this._nextRetainedDataId = this.editor.plugins.get('RetainedData').getNextId;

--- a/app/javascript/ckeditor/insertcontentblockcommand.js
+++ b/app/javascript/ckeditor/insertcontentblockcommand.js
@@ -1,0 +1,40 @@
+import Command from '@ckeditor/ckeditor5-core/src/command';
+
+export default class InsertContentBlockCommand extends Command {
+    execute( classes='module-block module-block-reflection' ) {
+        this.editor.model.change( writer => {
+            const { contentBlock, selection } = createContentBlock( writer, classes );
+            this.editor.model.insertContent( contentBlock );
+            writer.setSelection( selection );
+        } );
+    }
+
+    refresh() {
+        const model = this.editor.model;
+        const selection = model.document.selection;
+        const allowedIn = model.schema.findAllowedParent( selection.getFirstPosition(), 'moduleBlock' );
+
+        this.isEnabled = allowedIn !== null;
+    }
+}
+
+function createContentBlock( writer, classes ) {
+    const contentBlock = writer.createElement( 'moduleBlock', { 'class': classes } );
+    const content = writer.createElement( 'content' );
+    const contentTitle = writer.createElement( 'contentTitle' );
+    const contentBody = writer.createElement( 'contentBody' );
+
+    const contentParagraph = writer.createElement( 'paragraph' );
+
+    writer.append( content, contentBlock );
+    writer.append( contentTitle, content );
+    writer.append( contentBody, content );
+    // There must be at least one paragraph for the description to be editable.
+    // See https://github.com/ckeditor/ckeditor5/issues/1464.
+    writer.append( contentParagraph, contentBody );
+
+    // Return the created element and desired selection position.
+    const selection = writer.createPositionAt( contentTitle, 0 );
+
+    return { contentBlock, selection };
+}

--- a/app/javascript/ckeditor/inserttablecontentcommand.js
+++ b/app/javascript/ckeditor/inserttablecontentcommand.js
@@ -12,11 +12,16 @@ export default class InsertTableCommand extends Command {
         this.editor.model.change( writer => {
             const tableContent = writer.createElement( 'tableContent' );
             const content = writer.createElement( 'content' );
+            const contentTitle = writer.createElement( 'contentTitle' );
+            const contentBody = writer.createElement( 'contentBody' );
 
-            writer.append(content, tableContent);
+            writer.append( content, tableContent );
+            writer.append( contentTitle, content );
+            writer.append( contentBody, content );
 
+            // Insert table after the title and body.
             model.insertContent( tableContent );
-            writer.setSelection( writer.createPositionAt( content, 0 ) );
+            writer.setSelection( writer.createPositionAt( content, 2 ) );
             this.editor.execute( 'insertTable', { rows: rows, columns: columns } );
         } );
     }

--- a/app/javascript/components/ContentEditor.js
+++ b/app/javascript/components/ContentEditor.js
@@ -601,6 +601,15 @@ class ContentEditor extends Component {
                             </ul>
                             <ul key="content-part-list-content" className="widget-list">
                                 <ContentPartPreview
+                                    key="insertContentBlock"
+                                    enabled={this.state.enabledCommands.includes('insertContentBlock')}
+                                    onClick={( id ) => {
+                                        this.editor.execute( 'insertContentBlock' );
+                                        this.editor.editing.view.focus();
+                                    }}
+                                    {...{name: 'Text'}}
+                                />
+                                <ContentPartPreview
                                     key="insertTableContent"
                                     enabled={this.state.enabledCommands.includes('insertTableContent')}
                                     onClick={( id ) => {
@@ -621,16 +630,6 @@ class ContentEditor extends Component {
                                     {...{name: 'Quote'}}
                                 />
                                 <ContentPartPreview
-                                    key="insertIFrameContent"
-                                    enabled={this.state.enabledCommands.includes('insertIFrameContent')}
-                                    onClick={( id ) => {
-                                        const url = window.prompt('URL', 'http://example.com' );
-                                        this.editor.execute( 'insertIFrameContent', url );
-                                        this.editor.editing.view.focus();
-                                    }}
-                                    {...{name: 'iFrame'}}
-                                />
-                                <ContentPartPreview
                                     key="insertVideoContent"
                                     enabled={this.state.enabledCommands.includes('insertVideoContent')}
                                     onClick={( id ) => {
@@ -642,6 +641,16 @@ class ContentEditor extends Component {
                                 />
                             </ul>
                             <ul key="content-part-list-elements" className="widget-list">
+                                <ContentPartPreview
+                                    key="insertIFrameContent"
+                                    enabled={this.state.enabledCommands.includes('insertIFrameContent')}
+                                    onClick={( id ) => {
+                                        const url = window.prompt('URL', 'http://example.com' );
+                                        this.editor.execute( 'insertIFrameContent', url );
+                                        this.editor.editing.view.focus();
+                                    }}
+                                    {...{name: 'IFrame'}}
+                                />
                                 <ContentPartPreview
                                     key="insertTextArea"
                                     enabled={this.state.enabledCommands.includes('insertTextArea')}

--- a/app/javascript/components/ContentEditor.js
+++ b/app/javascript/components/ContentEditor.js
@@ -680,7 +680,7 @@ class ContentEditor extends Component {
                                 />
                                 <ContentPartPreview
                                     key="imageUpload"
-                                    enabled={this.state.enabledCommands.includes('imageUpload')}
+                                    enabled={false}
                                     onClick={this.showFileUpload}
                                     {...{name: 'Image (Upload)'}}
                                 />


### PR DESCRIPTION
Allow users to insert new text content blocks, and fix some minor issues in other buttons for consistency. 

Again, not much to review here. The new file is just a modified copy of the existing commands, they're all pretty much the same.

The one thing to note is that I tried to make the `class` attribute a parameter, but it's not currently working as expected - it just creates a `<div class="module-block">` regardless of what classes you pass in. I'm not sure why, but it's not a blocker at the moment so I'd like to get this in anyway.

Task: https://app.asana.com/0/1142638035116665/1169209719391251/f