### PR TITLE
Allow text in displayValueDiv

### DIFF
--- a/app/javascript/ckeditor/sliderquestionediting.js
+++ b/app/javascript/ckeditor/sliderquestionediting.js
@@ -26,6 +26,7 @@ export default class SliderQuestionEditing extends Plugin {
         schema.register( 'displayValueDiv', {
             isObject: true,
             allowIn: 'questionFieldset',
+            allowContentOf: [ '$block' ],
         } );
 
         schema.register( 'currentValueSpan', {


### PR DESCRIPTION
Task: https://app.asana.com/0/1142638035116665/1169263114925105/f

context: this element is where we show current-value for sliders. some sliders represent a percent, so they have a `%` symbol in them so that the value shows up as e.g. "50%" instead of "50". this allows us to put %s inside the div.