### PR TITLE
Handle share-release divs/checkboxes

### DIFF
--- a/app/javascript/ckeditor/checklistquestionediting.js
+++ b/app/javascript/ckeditor/checklistquestionediting.js
@@ -54,7 +54,7 @@ export default class ChecklistQuestionEditing extends Plugin {
         schema.register( 'checkboxInput', {
             isInline: true,
             isObject: true,
-            allowIn: [ 'checkboxDiv', 'tableCell', 'div' ],
+            allowIn: [ 'checkboxDiv', 'tableCell', '$root' ],
             allowAttributes: [ 'id', 'name', 'value', 'data-correctness' ].concat(ALLOWED_ATTRIBUTES),
         } );
 

--- a/app/javascript/ckeditor/checklistquestionediting.js
+++ b/app/javascript/ckeditor/checklistquestionediting.js
@@ -6,11 +6,12 @@ import RetainedData from './retaineddata';
 import InsertChecklistQuestionCommand from './insertchecklistquestioncommand';
 import InsertCheckboxCommand from './insertcheckboxcommand';
 import SetAttributesCommand from './setattributescommand';
-import { ALLOWED_ATTRIBUTES, filterAllowedAttributes } from './customelementattributepreservation.js';
+import CustomElementAttributePreservation from './customelementattributepreservation';
+import { ALLOWED_ATTRIBUTES, filterAllowedAttributes } from './customelementattributepreservation';
 
 export default class ChecklistQuestionEditing extends Plugin {
     static get requires() {
-        return [ Widget, RetainedData ];
+        return [ Widget, RetainedData, CustomElementAttributePreservation ];
     }
 
     init() {
@@ -51,10 +52,14 @@ export default class ChecklistQuestionEditing extends Plugin {
             allowIn: [ 'questionFieldset' ],
         } );
 
+        schema.extend( 'div', {
+            allowIn: 'checkboxDiv',
+        } );
+
         schema.register( 'checkboxInput', {
             isInline: true,
             isObject: true,
-            allowIn: [ 'checkboxDiv', 'tableCell' ],
+            allowIn: [ 'checkboxDiv', 'tableCell', 'div' ],
             allowAttributes: [ 'id', 'name', 'value', 'data-correctness' ].concat(ALLOWED_ATTRIBUTES),
         } );
 

--- a/app/javascript/ckeditor/checklistquestionediting.js
+++ b/app/javascript/ckeditor/checklistquestionediting.js
@@ -6,12 +6,11 @@ import RetainedData from './retaineddata';
 import InsertChecklistQuestionCommand from './insertchecklistquestioncommand';
 import InsertCheckboxCommand from './insertcheckboxcommand';
 import SetAttributesCommand from './setattributescommand';
-import CustomElementAttributePreservation from './customelementattributepreservation';
 import { ALLOWED_ATTRIBUTES, filterAllowedAttributes } from './customelementattributepreservation';
 
 export default class ChecklistQuestionEditing extends Plugin {
     static get requires() {
-        return [ Widget, RetainedData, CustomElementAttributePreservation ];
+        return [ Widget, RetainedData ];
     }
 
     init() {
@@ -50,10 +49,6 @@ export default class ChecklistQuestionEditing extends Plugin {
 
         schema.register( 'checkboxDiv', {
             allowIn: [ 'questionFieldset' ],
-        } );
-
-        schema.extend( 'div', {
-            allowIn: 'checkboxDiv',
         } );
 
         schema.register( 'checkboxInput', {

--- a/app/javascript/ckeditor/contentcommonediting.js
+++ b/app/javascript/ckeditor/contentcommonediting.js
@@ -7,11 +7,12 @@ import RetainedData from './retaineddata';
 import InsertTextInputCommand from './inserttextinputcommand';
 import InsertDoneButtonCommand from './insertdonebuttoncommand';
 import InsertContentBlockCommand from './insertcontentblockcommand';
-import { ALLOWED_ATTRIBUTES, filterAllowedAttributes } from './customelementattributepreservation.js';
+import CustomElementAttributePreservation from './customelementattributepreservation';
+import { ALLOWED_ATTRIBUTES, filterAllowedAttributes } from './customelementattributepreservation';
 
 export default class ContentCommonEditing extends Plugin {
     static get requires() {
-        return [ Widget, RetainedData, List ];
+        return [ Widget, RetainedData, List, CustomElementAttributePreservation ];
     }
 
     init() {
@@ -85,6 +86,10 @@ export default class ContentCommonEditing extends Plugin {
         } );
 
         schema.extend( 'listItem', {
+            allowIn: 'questionFieldset',
+        } );
+
+        schema.extend( 'div', {
             allowIn: 'questionFieldset',
         } );
 

--- a/app/javascript/ckeditor/contentcommonediting.js
+++ b/app/javascript/ckeditor/contentcommonediting.js
@@ -7,12 +7,11 @@ import RetainedData from './retaineddata';
 import InsertTextInputCommand from './inserttextinputcommand';
 import InsertDoneButtonCommand from './insertdonebuttoncommand';
 import InsertContentBlockCommand from './insertcontentblockcommand';
-import CustomElementAttributePreservation from './customelementattributepreservation';
 import { ALLOWED_ATTRIBUTES, filterAllowedAttributes } from './customelementattributepreservation';
 
 export default class ContentCommonEditing extends Plugin {
     static get requires() {
-        return [ Widget, RetainedData, List, CustomElementAttributePreservation ];
+        return [ Widget, RetainedData, List ];
     }
 
     init() {
@@ -86,10 +85,6 @@ export default class ContentCommonEditing extends Plugin {
         } );
 
         schema.extend( 'listItem', {
-            allowIn: 'questionFieldset',
-        } );
-
-        schema.extend( 'div', {
             allowIn: 'questionFieldset',
         } );
 
@@ -354,13 +349,14 @@ export default class ContentCommonEditing extends Plugin {
         conversion.for( 'upcast' ).elementToElement( {
             model: 'questionBody',
             view: {
-                name: 'div'
+                name: 'div',
             },
         } );
         conversion.for( 'dataDowncast' ).elementToElement( {
             model: 'questionBody',
             view: {
-                name: 'div'
+                name: 'div',
+                classes: [ 'question-body' ],
             }
         } );
         conversion.for( 'editingDowncast' ).elementToElement( {
@@ -571,13 +567,14 @@ export default class ContentCommonEditing extends Plugin {
         conversion.for( 'upcast' ).elementToElement( {
             model: 'answerText',
             view: {
-                name: 'div'
+                name: 'div',
             }
         } );
         conversion.for( 'dataDowncast' ).elementToElement( {
             model: 'answerText',
             view: {
-                name: 'div'
+                name: 'div',
+                classes: [ 'answer-body' ],
             }
         } );
         conversion.for( 'editingDowncast' ).elementToElement( {

--- a/app/javascript/ckeditor/customelementattributepreservation.js
+++ b/app/javascript/ckeditor/customelementattributepreservation.js
@@ -200,12 +200,16 @@ function setupAllowedAttributePreservation( editor ) {
         model: ( viewElement, modelWriter ) => {
             return modelWriter.createElement( 'div', filterAllowedAttributes( viewElement.getAttributes() ) );
         },
+        // Use low priority to make sure existing converters run first.
+        converterPriority: 'low'
     } );
     editor.conversion.for( 'upcast' ).elementToElement( {
         view: 'span',
         model: ( viewElement, modelWriter ) => {
             return modelWriter.createElement( 'span', filterAllowedAttributes( viewElement.getAttributes() ) );
         },
+        // Use low priority to make sure existing converters run first.
+        converterPriority: 'low'
     } );
 
     // Model-to-view converter for the <div> element (attrbiutes are converted separately).

--- a/app/javascript/ckeditor/customelementattributepreservation.js
+++ b/app/javascript/ckeditor/customelementattributepreservation.js
@@ -159,12 +159,15 @@ function setupAllowedAttributePreservation( editor ) {
     // Allow <div> elements in the model.
     editor.model.schema.register( 'div', {
         allowWhere: '$block',
+        allowIn: [ 'questionFieldset', 'checkboxDiv' ],
         allowContentOf: '$root'
     } );
 
     // Allow <span> elements in the model.
     editor.model.schema.register( 'span', {
+        isInline: true,
         allowWhere: '$block',
+        allowIn: '$block',
         allowContentOf: '$block'
     } );
 
@@ -188,8 +191,6 @@ function setupAllowedAttributePreservation( editor ) {
             model: ( viewElement, modelWriter ) => {
                 return modelWriter.createElement( elements[key], filterAllowedAttributes( viewElement.getAttributes() ) );
             },
-            // Use high priority to overwrite existing converters.
-            converterPriority: 'high'
         } );
     } );
 
@@ -200,8 +201,6 @@ function setupAllowedAttributePreservation( editor ) {
         model: ( viewElement, modelWriter ) => {
             return modelWriter.createElement( 'div', filterAllowedAttributes( viewElement.getAttributes() ) );
         },
-        // Use low priority to make sure existing converters run first.
-        converterPriority: 'low'
     } );
     editor.conversion.for( 'upcast' ).elementToElement( {
         view: 'span',

--- a/app/javascript/ckeditor/customelementattributepreservation.js
+++ b/app/javascript/ckeditor/customelementattributepreservation.js
@@ -174,9 +174,10 @@ function setupAllowedAttributePreservation( editor ) {
     // Elements we want to allow custom attribute preservation on.
     // { view: model }
     // Note: hN = heading(N-1) is a ckeditor5 convention.
+    // We can do all these with normal priority because the ones we define in ContentEditor.js
+    // in the CKE heading options are set to `low` priority.
     const elements = {
         'p': 'paragraph',
-        'td': 'tableCell',
         'h2': 'heading1',
         'h3': 'heading2',
         'h4': 'heading3',
@@ -194,8 +195,17 @@ function setupAllowedAttributePreservation( editor ) {
         } );
     } );
 
+    // TD converter must be high priority so it overrides the CKE builtin tableCell converters.
+    editor.conversion.for( 'upcast' ).elementToElement( {
+        view: 'td',
+        model: ( viewElement, modelWriter ) => {
+            return modelWriter.createElement( 'tableCell', filterAllowedAttributes( viewElement.getAttributes() ) );
+        },
+        // Use low priority to make sure existing converters run first.
+        converterPriority: 'high'
+    } );
 
-    // Div and span converters must be regular priority so they don't override more specific converters defined elsewhere.
+    // Div and span converters must be normal priority or lower so they don't override more specific converters defined elsewhere.
     editor.conversion.for( 'upcast' ).elementToElement( {
         view: 'div',
         model: ( viewElement, modelWriter ) => {

--- a/app/javascript/components/ContentEditor.js
+++ b/app/javascript/components/ContentEditor.js
@@ -166,12 +166,12 @@ BalloonEditor.defaultConfig = {
     },
     heading: {
         options: [
-            { model: 'paragraph', title: 'Paragraph', class: 'ck-heading_paragraph' },
-            { model: 'heading1', view: 'h2', title: 'Heading 1', class: 'ck-heading_h2' },
-            { model: 'heading2', view: 'h3', title: 'Heading 2', class: 'ck-heading_h3' },
-            { model: 'heading3', view: 'h4', title: 'Heading 3', class: 'ck-heading_h4' },
-            { model: 'heading4', view: 'h5', title: 'Heading 4', class: 'ck-heading_h5' },
-            { model: 'heading5', view: 'h6', title: 'Heading 5', class: 'ck-heading_h6' },
+            { model: 'paragraph', title: 'Paragraph', class: 'ck-heading_paragraph', converterPriority: 'low' },
+            { model: 'heading1', view: 'h2', title: 'Heading 1', class: 'ck-heading_h2', converterPriority: 'low' },
+            { model: 'heading2', view: 'h3', title: 'Heading 2', class: 'ck-heading_h3', converterPriority: 'low' },
+            { model: 'heading3', view: 'h4', title: 'Heading 3', class: 'ck-heading_h4', converterPriority: 'low' },
+            { model: 'heading4', view: 'h5', title: 'Heading 4', class: 'ck-heading_h5', converterPriority: 'low' },
+            { model: 'heading5', view: 'h6', title: 'Heading 5', class: 'ck-heading_h6', converterPriority: 'low' },
         ]
     },
     simpleUpload: {


### PR DESCRIPTION
Task: https://app.asana.com/0/1142638035116665/1169382763057601/f

Summary: allows the custom "div" element inside `checkboxDiv` and `questionFieldset`, because those are the two places we currently use `div class="share-release"`.

example: 
<img width="643" alt="Screen Shot 2020-04-02 at 1 42 59 PM" src="https://user-images.githubusercontent.com/1382374/78289493-e404ab00-74e7-11ea-931d-7fafd96839fd.png">

context / things to note: This "custom div" code is super fragile, and our goal should be to eventually phase it out. We can do this by implementing more things (like this share-release div) as fully supported elements, and/or by removing them from the modules entirely (this should be preferred).