### PR TITLE
Move save button, remove unused links

### DIFF
--- a/app/javascript/components/ContentEditor.js
+++ b/app/javascript/components/ContentEditor.js
@@ -369,6 +369,9 @@ class ContentEditor extends Component {
                         <li onClick={(evt) => this.handlePublish(evt)} className={this.state['isPublished'] ? "success" : ""}>
                           Publish{this.state['isPublished'] ? "ed" : ""} {this.state['isPublished']}
                         </li>
+                        <li onClick={(evt) => document.forms[0].submit()}>
+                          Save
+                        </li>
                     </ul>
 
                 </header>

--- a/app/views/course_contents/_form.html.erb
+++ b/app/views/course_contents/_form.html.erb
@@ -40,8 +40,4 @@
         ]
                     }) %>
   </div>
-
-  <div class="actions">
-    <%= form.submit %>
-  </div>
 <% end %>

--- a/app/views/course_contents/edit.html.erb
+++ b/app/views/course_contents/edit.html.erb
@@ -1,4 +1,1 @@
 <%= render 'form', course_content: @course_content %>
-
-<%= link_to 'Show', @course_content %> |
-<%= link_to 'Back', course_contents_path %>

--- a/app/views/course_contents/new.html.erb
+++ b/app/views/course_contents/new.html.erb
@@ -1,3 +1,1 @@
 <%= render 'form', course_content: @course_content %>
-
-<%= link_to 'Back', course_contents_path %>


### PR DESCRIPTION
Summary: Save button was hidden behind other links and in some cases the editor component itself, making it hard to click. There's now a save button at the top of the screen, next to publish.

Task: https://app.asana.com/0/1142638035116665/1170308508489041/f

Before:
<img width="595" alt="Screen Shot 2020-04-08 at 12 27 27 PM" src="https://user-images.githubusercontent.com/1382374/78814544-6aac0300-7994-11ea-9816-cc9452f9aabc.png">

After: 
<img width="500" alt="Screen Shot 2020-04-08 at 12 25 09 PM" src="https://user-images.githubusercontent.com/1382374/78814295-025d2180-7994-11ea-9957-2b84ea7a6e85.png">


