### PR TITLE
Add advanced page options

### DIFF
--- a/app/javascript/components/ContentEditor.js
+++ b/app/javascript/components/ContentEditor.js
@@ -387,6 +387,25 @@ class ContentEditor extends Component {
                                        placeholder="Page Title"
                                 />
                             </h2>
+                            <details>
+                              <summary>Advanced</summary>
+                              <select name="course_content[content_type]"
+                                      defaultValue={this.props.course_content['content_type']}
+                                      placeholder="Content Type">
+                                <option value="">SELECT PAGE TYPE</option>
+                                <option value="wiki_page">Module</option>
+                                <option value="assignment">Project</option>
+                              </select>
+                              <br/>
+                              <input type="number" name="course_content[course_id]"
+                                     defaultValue={this.props.course_content['course_id']}
+                                     placeholder="Course ID"
+                              />
+                              <input type="text" name="course_content[secondary_id]"
+                                     defaultValue={this.props.course_content['secondary_id']}
+                                     placeholder="Secondary ID"
+                              />
+                            </details>
                         </div>
                         <div id="toolbar-contextual">
                             {this.state.modelPath.map( modelElement => {


### PR DESCRIPTION
There's no task for this.

Summary: Adds more `CourseContent` fields to the editor UI, so they're easier to set/update.

Screenshot:
<img width="295" alt="Screen Shot 2020-04-09 at 2 38 08 PM" src="https://user-images.githubusercontent.com/1382374/78933981-c1d2d600-7a6f-11ea-80f8-9c4088d3d460.png">

Context: The way i've been doing this is going through heroku web interface -> staging platform console -> find the `CourseContent` with the right id -> set each of the 3 fields correctly -> save the record -> back to editor -> publish. Now I can just fill out the fields in the editor -> save -> publish. This'll save me a lot of time.