### PR TITLE
On save, show the edit page

### DIFF
--- a/app/controllers/course_contents_controller.rb
+++ b/app/controllers/course_contents_controller.rb
@@ -30,7 +30,7 @@ class CourseContentsController < ApplicationController
 
     respond_to do |format|
       if @course_content.save
-        format.html { redirect_to @course_content, notice: 'CourseContent was successfully created.' }
+        format.html { redirect_to edit_course_content_path(@course_content), notice: 'CourseContent was successfully created.' }
         format.json { render :show, status: :created, location: @course_content }
       else
         format.html { render :new }
@@ -44,7 +44,7 @@ class CourseContentsController < ApplicationController
   def update
     respond_to do |format|
       if @course_content.update(course_content_params)
-        format.html { redirect_to @course_content, notice: 'CourseContent was successfully updated.' }
+        format.html { redirect_to edit_course_content_path(@course_content), notice: 'CourseContent was successfully updated.' }
         format.json { render :show, status: :ok, location: @course_content }
       else
         format.html { render :edit }

--- a/app/views/course_contents/edit.html.erb
+++ b/app/views/course_contents/edit.html.erb
@@ -1,3 +1,5 @@
+<div class="alert alert-info" id="notice" role="alert"><%= notice %></div>
+
 <%= render 'form', course_content: @course_content %>
 
 <%= link_to 'Show', @course_content %> |

--- a/spec/controllers/course_contents_controller_spec.rb
+++ b/spec/controllers/course_contents_controller_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe CourseContentsController, type: :controller do
 
       it "redirects to the created course_content" do
         post :create, params: {course_content: valid_attributes}, session: valid_session
-        expect(response).to redirect_to(CourseContent.last)
+        expect(response).to redirect_to(edit_course_content_path(CourseContent.last))
       end
     end
 
@@ -118,7 +118,7 @@ RSpec.describe CourseContentsController, type: :controller do
       it "redirects to the course_content" do
         course_content = CourseContent.create! valid_attributes
         put :update, params: {id: course_content.to_param, course_content: valid_attributes}, session: valid_session
-        expect(response).to redirect_to(course_content)
+        expect(response).to redirect_to(edit_course_content_path(course_content))
       end
     end
 


### PR DESCRIPTION
There's no task for this.

Summary: Instead of going to a messy "show" page after saving, just show the editor page again. 

Before:
<img width="460" alt="Screen Shot 2020-04-09 at 3 01 38 PM" src="https://user-images.githubusercontent.com/1382374/78935811-1035a400-7a73-11ea-888b-bd8c157d2d14.png">

After:
<img width="460" alt="Screen Shot 2020-04-09 at 3 01 48 PM" src="https://user-images.githubusercontent.com/1382374/78935828-17f54880-7a73-11ea-9929-b43768046497.png">
