### PR TITLE
Allow all inputs inside fieldset

### DIFF
--- a/app/javascript/ckeditor/contentcommonediting.js
+++ b/app/javascript/ckeditor/contentcommonediting.js
@@ -123,7 +123,7 @@ export default class ContentCommonEditing extends Plugin {
         schema.register( 'textInput', {
             isObject: true,
             allowAttributes: [ 'type', 'placeholder' ].concat(ALLOWED_ATTRIBUTES),
-            allowIn: [ '$root', '$block', 'tableCell' ],
+            allowIn: [ '$root', '$block', 'tableCell', 'questionFieldset' ],
         } );
 
         schema.register( 'textArea', {
@@ -135,7 +135,7 @@ export default class ContentCommonEditing extends Plugin {
         schema.register( 'fileUpload', {
             isObject: true,
             allowAttributes: [ 'class', 'type' ].concat(ALLOWED_ATTRIBUTES),
-            allowIn: [ '$root' ],
+            allowIn: [ '$root', 'questionFieldset' ],
         } );
 
         schema.register( 'slider', {
@@ -147,7 +147,7 @@ export default class ContentCommonEditing extends Plugin {
         schema.register( 'select', {
             isObject: true,
             allowAttributes: [ 'id', 'name' ].concat(ALLOWED_ATTRIBUTES),
-            allowIn: [ '$root' ],
+            allowIn: [ '$root', 'questionFieldset' ],
         } );
 
         schema.register( 'selectOption', {


### PR DESCRIPTION
Task: https://app.asana.com/0/1142638035116665/1170711919744948/f

Summary: Normalize where input-type elements are allowed - all of them should be allowed inside fieldsets.

This is a blocker for module 3.