### PR TITLE
Render portal images correctly in the editor

### DIFF
--- a/app/javascript/ckeditor/portalimageediting.js
+++ b/app/javascript/ckeditor/portalimageediting.js
@@ -1,0 +1,43 @@
+import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+
+import { getViewImgFromWidget } from '@ckeditor/ckeditor5-image/src/image/utils';
+
+const PORTAL_URL = 'https://portal.bebraven.org'
+
+export default class PortalImageEditing extends Plugin {
+
+    static get pluginName() {
+        return 'PortalImageEditing';
+    }
+
+    init() {
+        const editor = this.editor;
+        const conversion = editor.conversion;
+
+        // Add a custom converter to the end of the chain for CKEditor's builtin image editing downcast.
+        conversion.for( 'editingDowncast' ).add( modelToViewAttributeConverter( 'src' ) );
+    }
+}
+
+// See https://github.com/ckeditor/ckeditor5-image/blob/1b8369f8b380b1f3d107586b9bdfa43e0ab8a603/src/image/converters.js#L114
+export function modelToViewAttributeConverter( attributeKey ) {
+    return dispatcher => {
+        dispatcher.on( `attribute:${ attributeKey }:image`, converter );
+    };
+
+    function converter( evt, data, conversionApi ) {
+        const viewWriter = conversionApi.writer;
+        const figure = conversionApi.mapper.toViewElement( data.item );
+        const img = getViewImgFromWidget( figure );
+
+        // If the src attribute starts with '/', prepend PORTAL_URL, so the image renders.
+        if ( data.attributeKey === 'src' && data.attributeNewValue.startsWith( '/' ) ) {
+            viewWriter.setAttribute( data.attributeKey, PORTAL_URL + data.attributeNewValue, img );
+        } else if ( data.attributeNewValue !== null ) {
+            viewWriter.setAttribute( data.attributeKey, data.attributeNewValue, img );
+        } else {
+            viewWriter.removeAttribute( data.attributeKey, img );
+        }
+    }
+}
+

--- a/app/javascript/components/ContentEditor.js
+++ b/app/javascript/components/ContentEditor.js
@@ -53,6 +53,7 @@ import BlockquoteContentEditing from '../ckeditor/blockquotecontentediting';
 import IFrameContentEditing from '../ckeditor/iframecontentediting';
 import VideoContentEditing from '../ckeditor/videocontentediting';
 import SectionEditing from '../ckeditor/sectionediting';
+import PortalImageEditing from '../ckeditor/portalimageediting';
 
 import Tooltip from '../ckeditor/tooltip';
 import ImageLink from '../ckeditor/imagelink';
@@ -106,6 +107,7 @@ BalloonEditor.builtinPlugins = [
     IFrameContentEditing,
     VideoContentEditing,
     SectionEditing,
+    PortalImageEditing,
 ];
 
 // Editor configuration.


### PR DESCRIPTION
Task: https://app.asana.com/0/1142638035116665/1170693002395763/f

Summary: Prepend `https://portal.bebraven.org` to image `src` attributes that begin with `/`, only in the editing view.

Context: We have a lot of images in modules that have `src='/blah'`, and they don't render in the editor because it's hosted on a different domain than canvas. This PR makes it easier to edit existing modules. By using this custom converter on the editingDowncast chain ONLY, we avoid modifying any of the actual content, so it works transparently when publishing to portal. 

Before:
<img width="639" alt="Screen Shot 2020-04-09 at 3 50 01 PM" src="https://user-images.githubusercontent.com/1382374/78939468-d4eaa380-7a79-11ea-8857-ed56d48e65b8.png">

After:
<img width="639" alt="Screen Shot 2020-04-09 at 3 50 15 PM" src="https://user-images.githubusercontent.com/1382374/78939481-dddb7500-7a79-11ea-922e-b0c09d8c33b4.png">
