### PR TITLE
Fix editor video selection

### DIFF
--- a/app/javascript/ckeditor/videocontentediting.js
+++ b/app/javascript/ckeditor/videocontentediting.js
@@ -39,16 +39,19 @@ export default class VideoContentEditing extends Plugin {
 
         schema.register( 'videoCaption', {
             allowIn: 'videoFigCaption',
+            isLimit: true,
             allowContentOf: [ '$block' ],
         } );
 
         schema.register( 'videoDuration', {
             allowIn: 'videoFigCaption',
+            isLimit: true,
             allowContentOf: [ '$block' ],
         } );
 
         schema.register( 'videoTranscript', {
             allowIn: 'videoFigCaption',
+            isLimit: true,
             allowContentOf: [ '$root' ],
         } );
     }


### PR DESCRIPTION
Task: https://app.asana.com/0/1142638035116665/1169461014498427/f

Setting the elements as limits prevents the cursor from escaping them, which means select-all inside one of them only selects all the contents of that element.