### PR TITLE
Allow inserting options with the entire option selected, instead of just inside the label

### DIFF
--- a/app/javascript/ckeditor/checklistquestionediting.js
+++ b/app/javascript/ckeditor/checklistquestionediting.js
@@ -30,8 +30,10 @@ export default class ChecklistQuestionEditing extends Plugin {
             evt.stop();
         } );
 
-        // For some reason 'enter' events don't fire when the current selection is a checkboxDiv,
-        // so fix that explicitly.
+        // Because 'enter' events are consumed by Widget._onKeydown when the current selection is a non-inline
+        // block widget, we have to re-fire them explicitly for checkboxDivs.
+        // https://github.com/ckeditor/ckeditor5-widget/blob/bdeec63534d11a4fa682bb34990c698435bc13e3/src/widget.js#L174
+        // https://github.com/ckeditor/ckeditor5-widget/blob/bdeec63534d11a4fa682bb34990c698435bc13e3/src/widget.js#L408
         this.listenTo( this.editor.editing.view.document, 'keydown', ( evt, data ) => {
             const selection = this.editor.model.document.selection;
             const selectedElement = selection.getSelectedElement();
@@ -44,6 +46,8 @@ export default class ChecklistQuestionEditing extends Plugin {
                     evt.stop();
                 }
             }
+        // Use 'highest' priority, because Widget._onKeydown listens at 'high'.
+        // https://github.com/ckeditor/ckeditor5-widget/blob/bdeec63534d11a4fa682bb34990c698435bc13e3/src/widget.js#L92
         }, { priority: 'highest' } );
 
         // Override the default 'enter' key behavior to allow inserting new checklist options.

--- a/app/javascript/ckeditor/insertcheckboxcommand.js
+++ b/app/javascript/ckeditor/insertcheckboxcommand.js
@@ -1,16 +1,28 @@
 import Command from '@ckeditor/ckeditor5-core/src/command';
-import { findAllowedParentIgnoreLimit } from './utils';
+import { findAllowedParentIgnoreLimit, getNamedAncestor } from './utils';
 
 export default class InsertCheckboxCommand extends Command {
     execute() {
         this.editor.model.change( writer => {
-            // NOTE: We're making a huge assumption here that we'll only ever call this command while
-            // the current selection is *inside* a checkbox label. If that ever changes, we'll need to
-            // add some extra logic here.
-            // Before inserting, modify the current selection to after the checkboxDiv (the grandparent
-            // of the current selection, iff the aforementioned assumption holds true).
-            const grandparentCheckboxDiv = this.editor.model.document.selection.focus.parent.parent;
-            writer.setSelection( grandparentCheckboxDiv, 'after' );
+            // Before inserting, modify the current selection to after the checkboxDiv.
+            const selection = this.editor.model.document.selection;
+            const selectedElement = selection.getSelectedElement();
+            const position = selection.getFirstPosition();
+
+            // Find the checkboxDiv.
+            let checkboxDiv;
+            if ( selectedElement && selectedElement.name === 'checkboxDiv' ) {
+                // The current selection is a checkboxDiv.
+                checkboxDiv = selectedElement;
+            } else if ( [ 'checkboxLabel', 'checkboxInlineFeedback' ].includes(position.parent.name) ) {
+                // The cursor is inside one of the elements in the checkboxDiv, so find its ancestor checkboxDiv.
+                checkboxDiv = getNamedAncestor( 'checkboxDiv', position );
+            } else {
+                // In any other case, just return without doing anything.
+                // This makes us a bit more robust, in case we modify checkboxDiv later on.
+                return;
+            }
+            writer.setSelection( checkboxDiv, 'after' );
             this.editor.model.insertContent( createCheckbox( writer ) );
         } );
     }
@@ -18,6 +30,9 @@ export default class InsertCheckboxCommand extends Command {
     refresh() {
         const model = this.editor.model;
         const selection = model.document.selection;
+
+        // Explicitly ignore Limit behavior, because checkboxLabel is a limit.
+        // This feels hacky, but should be safe here.
         const allowedIn = findAllowedParentIgnoreLimit( model.schema, selection.getFirstPosition(), 'checkboxDiv' );
 
         this.isEnabled = allowedIn !== null;

--- a/app/javascript/ckeditor/insertradiocommand.js
+++ b/app/javascript/ckeditor/insertradiocommand.js
@@ -1,16 +1,28 @@
 import Command from '@ckeditor/ckeditor5-core/src/command';
-import { findAllowedParentIgnoreLimit } from './utils';
+import { findAllowedParentIgnoreLimit, getNamedAncestor } from './utils';
 
 export default class InsertRadioCommand extends Command {
     execute() {
         this.editor.model.change( writer => {
-            // NOTE: We're making a huge assumption here that we'll only ever call this command while
-            // the current selection is *inside* a radio label. If that ever changes, we'll need to
-            // add some extra logic here.
-            // Before inserting, modify the current selection to after the radioDiv (the grandparent
-            // of the current selection, iff the aforementioned assumption holds true).
-            const grandparentRadioDiv = this.editor.model.document.selection.focus.parent.parent;
-            writer.setSelection( grandparentRadioDiv, 'after' );
+            // Before inserting, modify the current selection to after the radioDiv.
+            const selection = this.editor.model.document.selection;
+            const selectedElement = selection.getSelectedElement();
+            const position = selection.getFirstPosition();
+
+            // Find the radioDiv.
+            let radioDiv;
+            if ( selectedElement && selectedElement.name === 'radioDiv' ) {
+                // The current selection is a radioDiv.
+                radioDiv = selectedElement;
+            } else if ( [ 'radioLabel', 'radioInlineFeedback' ].includes(position.parent.name) ) {
+                // The cursor is inside one of the elements in the radioDiv, so find its ancestor radioDiv.
+                radioDiv = getNamedAncestor( 'radioDiv', position );
+            } else {
+                // In any other case, just return without doing anything.
+                // This makes us a bit more robust, in case we modify radioDiv later on.
+                return;
+            }
+            writer.setSelection( radioDiv, 'after' );
             this.editor.model.insertContent( createRadio( writer ) );
         } );
     }
@@ -18,6 +30,9 @@ export default class InsertRadioCommand extends Command {
     refresh() {
         const model = this.editor.model;
         const selection = model.document.selection;
+
+        // Explicitly ignore Limit behavior, because radioLabel is a limit.
+        // This feels hacky, but should be safe here.
         const allowedIn = findAllowedParentIgnoreLimit( model.schema, selection.getFirstPosition(), 'radioDiv' );
 
         this.isEnabled = allowedIn !== null;

--- a/app/javascript/ckeditor/radioquestionediting.js
+++ b/app/javascript/ckeditor/radioquestionediting.js
@@ -22,8 +22,10 @@ export default class RadioQuestionEditing extends Plugin {
         // Add a shortcut to the retained data ID function.
         this._nextRetainedDataId = this.editor.plugins.get('RetainedData').getNextId;
 
-        // For some reason 'enter' events don't fire when the current selection is a radioDiv,
-        // so fix that explicitly.
+        // Because 'enter' events are consumed by Widget._onKeydown when the current selection is a non-inline
+        // block widget, we have to re-fire them explicitly for radioDivs.
+        // https://github.com/ckeditor/ckeditor5-widget/blob/bdeec63534d11a4fa682bb34990c698435bc13e3/src/widget.js#L174
+        // https://github.com/ckeditor/ckeditor5-widget/blob/bdeec63534d11a4fa682bb34990c698435bc13e3/src/widget.js#L408
         this.listenTo( this.editor.editing.view.document, 'keydown', ( evt, data ) => {
             const selection = this.editor.model.document.selection;
             const selectedElement = selection.getSelectedElement();
@@ -36,6 +38,8 @@ export default class RadioQuestionEditing extends Plugin {
                     evt.stop();
                 }
             }
+        // Use 'highest' priority, because Widget._onKeydown listens at 'high'.
+        // https://github.com/ckeditor/ckeditor5-widget/blob/bdeec63534d11a4fa682bb34990c698435bc13e3/src/widget.js#L92
         }, { priority: 'highest' } );
 
         // Override the default 'enter' key behavior to allow inserting new checklist options.

--- a/app/javascript/ckeditor/radioquestionediting.js
+++ b/app/javascript/ckeditor/radioquestionediting.js
@@ -22,19 +22,34 @@ export default class RadioQuestionEditing extends Plugin {
         // Add a shortcut to the retained data ID function.
         this._nextRetainedDataId = this.editor.plugins.get('RetainedData').getNextId;
 
-        // Override the default 'enter' key behavior for radio labels.
-        this.listenTo( this.editor.editing.view.document, 'enter', ( evt, data ) => {
-            const positionParent = this.editor.model.document.selection.getLastPosition().parent;
-            if ( positionParent.name == 'radioLabel' ) {
-                // Only insert a new radio if the current label is empty, but stop the event from
-                // propogating regardless.
-                if (!positionParent.isEmpty) {
-                    this.editor.execute( 'insertRadio' )
+        // For some reason 'enter' events don't fire when the current selection is a radioDiv,
+        // so fix that explicitly.
+        this.listenTo( this.editor.editing.view.document, 'keydown', ( evt, data ) => {
+            const selection = this.editor.model.document.selection;
+            const selectedElement = selection.getSelectedElement();
+
+            if ( selectedElement && selectedElement.name == 'radioDiv' ) {
+                if ( data.domEvent.key === 'Enter' ) {
+                    // This will end up calling our enter listener below.
+                    this.editor.editing.view.document.fire( 'enter', { evt, data } );
+                    data.preventDefault();
+                    evt.stop();
                 }
+            }
+        }, { priority: 'highest' } );
+
+        // Override the default 'enter' key behavior to allow inserting new checklist options.
+        this.listenTo( this.editor.editing.view.document, 'enter', ( evt, data ) => {
+            const selection = this.editor.model.document.selection;
+            const positionParent = selection.getLastPosition().parent;
+            const selectedElement = selection.getSelectedElement();
+
+            if ( positionParent.name == 'radioLabel' || ( selectedElement && selectedElement.name == 'radioDiv' ) ) {
+                this.editor.execute( 'insertRadio' )
                 data.preventDefault();
                 evt.stop();
             }
-        });
+        } );
     }
 
     _defineSchema() {


### PR DESCRIPTION
Task: https://app.asana.com/0/1170776727341290/1170308508489046/f

This is another one where I don't fully understand why it works this way.

As a side-effect of this PR, the `insertCheckbox` / `insertRadio` commands are much more robust and less hardcoded-y.

To test: 

1. Insert a section
2. insert a checkbox (or radio) question
3. select the option, outside the checkbox label or inline feedback, so the blue outline shows up.
4. hit enter; note that a new option is inserted after the current option.
