### PR TITLE
Don't delete options by typing

### DIFF
--- a/app/javascript/ckeditor/checklistquestionediting.js
+++ b/app/javascript/ckeditor/checklistquestionediting.js
@@ -37,12 +37,14 @@ export default class ChecklistQuestionEditing extends Plugin {
             const selectedElement = selection.getSelectedElement();
 
             if ( selectedElement && selectedElement.name == 'checkboxDiv' ) {
+                if (data.domEvent.key === 'Backspace') {
+                    return;
+                }
                 if ( data.domEvent.key === 'Enter' ) {
                     // This will end up calling our enter listener below.
                     this.editor.editing.view.document.fire( 'enter', { evt, data } );
-                    data.preventDefault();
-                    evt.stop();
                 }
+                evt.stop();
             }
         }, { priority: 'highest' } );
 

--- a/app/javascript/ckeditor/radioquestionediting.js
+++ b/app/javascript/ckeditor/radioquestionediting.js
@@ -29,12 +29,14 @@ export default class RadioQuestionEditing extends Plugin {
             const selectedElement = selection.getSelectedElement();
 
             if ( selectedElement && selectedElement.name == 'radioDiv' ) {
+                if (data.domEvent.key === 'Backspace') {
+                    return;
+                }
                 if ( data.domEvent.key === 'Enter' ) {
                     // This will end up calling our enter listener below.
                     this.editor.editing.view.document.fire( 'enter', { evt, data } );
-                    data.preventDefault();
-                    evt.stop();
                 }
+                evt.stop();
             }
         }, { priority: 'highest' } );
 


### PR DESCRIPTION
**Task**: https://app.asana.com/0/1170776727341290/1171026326095793

**Test**: 
- Add section, add {radio, checklist}question
- Click on option, verify Enter adds a new one, Backspace deletes, any other keydown does nothing

This is really straightforward to do on top of Ryan's `editor-insertcheckbox` changes. 