### PR TITLE
Allow designers to edit video/iframe URLs

### DIFF
--- a/app/assets/stylesheets/course_contents.scss
+++ b/app/assets/stylesheets/course_contents.scss
@@ -135,6 +135,14 @@ div.partial-html-document:after {
    clear: both;
 }
 
+.ck iframe.ck-widget,
+.ck iframe.ck-widget.ck-widget_selected,
+.ck iframe.ck-widget.ck-widget_selected:hover {
+        outline-width: 10px;
+        outline-offset: -10px;
+        padding: 10px;
+}
+
 /* --- Right sidebar styles --- */
 ul.widget-list li.disabled,
 ul.widget-list li.disabled:hover {

--- a/app/javascript/ckeditor/contentcommonediting.js
+++ b/app/javascript/ckeditor/contentcommonediting.js
@@ -840,5 +840,6 @@ export default class ContentCommonEditing extends Plugin {
         // and https://ckeditor.com/docs/ckeditor5/latest/api/module_engine_conversion_conversion-Conversion.html#function-attributeToAttribute
         conversion.attributeToAttribute( { model: 'data-correctness', view: 'data-correctness' } );
         conversion.attributeToAttribute( { model: 'placeholder', view: 'placeholder' } );
+        conversion.attributeToAttribute( { model: 'src', view: 'src' } );
     }
 }

--- a/app/javascript/components/ContentEditor.js
+++ b/app/javascript/components/ContentEditor.js
@@ -741,7 +741,7 @@ class ContentEditor extends Component {
                                     key="insertIFrameContent"
                                     enabled={this.state.enabledCommands.includes('insertIFrameContent')}
                                     onClick={( id ) => {
-                                        const url = window.prompt('URL', 'http://example.com' );
+                                        const url = window.prompt('URL', 'https://www.youtube.com/embed/yyRrKMb8oIg?rel=0' );
                                         this.editor.execute( 'insertIFrameContent', url );
                                         this.editor.editing.view.focus();
                                     }}

--- a/app/javascript/components/ContentEditor.js
+++ b/app/javascript/components/ContentEditor.js
@@ -594,6 +594,22 @@ class ContentEditor extends Component {
                                             <label htmlFor='input-mastery'>Mastery Question</label>
                                         </>
                                     );
+                                } else if ( [ 'videoIFrame', 'iframe' ].includes( modelElement ) ) {
+                                    // Videos and iframes have URL settings.
+                                    return (
+                                        <>
+                                            <h4>Video / IFrame</h4>
+                                            <input
+                                                type='text'
+                                                id='input-url'
+                                                defaultValue={this.state['selectedElement'].getAttribute('src')}
+                                                onChange={( evt ) => {
+                                                    this.editor.execute( 'setAttributes', { 'src': evt.target.value } );
+                                                }}
+                                            />
+                                            <label htmlFor='input-url'>URL</label>
+                                        </>
+                                    );
                                 }
                             } )
                         }


### PR DESCRIPTION
Task: https://app.asana.com/0/1170776727341290/1172440855762345/f

3 things included in this PR:

* New context-sensitive right sidebar block for videos and iframes
* New attributeToAttribute converter so `src` live-updates in the editing view
* CSS to make the border thicker on iframes, so they're easier to select.

We can't use the CKE selection handle on iframes unfortunately; see https://github.com/ckeditor/ckeditor5/issues/6650 for more details. This CSS change is my workaround for that. If anyone has better CSS ideas, let me know!