### PR TITLE
Don't execute click handler when disabled buttons at clicked

### DIFF
--- a/app/javascript/components/ContentEditor.js
+++ b/app/javascript/components/ContentEditor.js
@@ -625,6 +625,7 @@ class ContentEditor extends Component {
                                         this.editor.execute( 'insertSection' );
                                         this.editor.editing.view.focus();
                                     }}
+                                    onClickDisabled={() => this.editor.editing.view.focus()}
                                     {...{name: 'Section'}}
                                 />
                             </ul>
@@ -636,6 +637,7 @@ class ContentEditor extends Component {
                                         this.editor.execute( 'insertChecklistQuestion' );
                                         this.editor.editing.view.focus();
                                     }}
+                                    onClickDisabled={() => this.editor.editing.view.focus()}
                                     {...{name: 'Checklist Question'}}
                                 />
                                 <ContentPartPreview
@@ -645,6 +647,7 @@ class ContentEditor extends Component {
                                         this.editor.execute( 'insertRadioQuestion' );
                                         this.editor.editing.view.focus();
                                     }}
+                                    onClickDisabled={() => this.editor.editing.view.focus()}
                                     {...{name: 'Radio Question'}}
                                 />
                                 <ContentPartPreview
@@ -654,6 +657,7 @@ class ContentEditor extends Component {
                                         this.editor.execute( 'insertMatchingQuestion' );
                                         this.editor.editing.view.focus();
                                     }}
+                                    onClickDisabled={() => this.editor.editing.view.focus()}
                                     {...{name: 'Matching Question'}}
                                 />
                                 <ContentPartPreview
@@ -665,6 +669,7 @@ class ContentEditor extends Component {
                                         this.editor.execute( 'insertMatrixQuestion', {rows: rows, columns: columns} );
                                         this.editor.editing.view.focus();
                                     }}
+                                    onClickDisabled={() => this.editor.editing.view.focus()}
                                     {...{name: 'Matrix Question'}}
                                 />
                                 <ContentPartPreview
@@ -674,6 +679,7 @@ class ContentEditor extends Component {
                                         this.editor.execute( 'insertTextAreaQuestion' );
                                         this.editor.editing.view.focus();
                                     }}
+                                    onClickDisabled={() => this.editor.editing.view.focus()}
                                     {...{name: 'Text Area Question'}}
                                 />
                                 <ContentPartPreview
@@ -683,6 +689,7 @@ class ContentEditor extends Component {
                                         this.editor.execute( 'insertSliderQuestion' );
                                         this.editor.editing.view.focus();
                                     }}
+                                    onClickDisabled={() => this.editor.editing.view.focus()}
                                     {...{name: 'Slider Question'}}
                                 />
                                 <ContentPartPreview
@@ -692,6 +699,7 @@ class ContentEditor extends Component {
                                         this.editor.execute( 'insertFileUploadQuestion' );
                                         this.editor.editing.view.focus();
                                     }}
+                                    onClickDisabled={() => this.editor.editing.view.focus()}
                                     {...{name: 'File Upload Question'}}
                                 />
                             </ul>
@@ -703,6 +711,7 @@ class ContentEditor extends Component {
                                         this.editor.execute( 'insertContentBlock' );
                                         this.editor.editing.view.focus();
                                     }}
+                                    onClickDisabled={() => this.editor.editing.view.focus()}
                                     {...{name: 'Text'}}
                                 />
                                 <ContentPartPreview
@@ -714,6 +723,7 @@ class ContentEditor extends Component {
                                         this.editor.execute( 'insertTableContent', {rows: rows, columns: columns} );
                                         this.editor.editing.view.focus();
                                     }}
+                                    onClickDisabled={() => this.editor.editing.view.focus()}
                                     {...{name: 'Table'}}
                                 />
                                 <ContentPartPreview
@@ -723,6 +733,7 @@ class ContentEditor extends Component {
                                         this.editor.execute( 'insertBlockquoteContent' );
                                         this.editor.editing.view.focus();
                                     }}
+                                    onClickDisabled={() => this.editor.editing.view.focus()}
                                     {...{name: 'Quote'}}
                                 />
                                 <ContentPartPreview
@@ -733,6 +744,7 @@ class ContentEditor extends Component {
                                         this.editor.execute( 'insertVideoContent', url );
                                         this.editor.editing.view.focus();
                                     }}
+                                    onClickDisabled={() => this.editor.editing.view.focus()}
                                     {...{name: 'Video'}}
                                 />
                             </ul>
@@ -745,6 +757,7 @@ class ContentEditor extends Component {
                                         this.editor.execute( 'insertIFrameContent', url );
                                         this.editor.editing.view.focus();
                                     }}
+                                    onClickDisabled={() => this.editor.editing.view.focus()}
                                     {...{name: 'IFrame'}}
                                 />
                                 <ContentPartPreview
@@ -754,6 +767,7 @@ class ContentEditor extends Component {
                                         this.editor.execute( 'insertTextArea' );
                                         this.editor.editing.view.focus();
                                     }}
+                                    onClickDisabled={() => this.editor.editing.view.focus()}
                                     {...{name: 'Text Area'}}
                                 />
                                 <ContentPartPreview
@@ -763,6 +777,7 @@ class ContentEditor extends Component {
                                         this.editor.execute( 'insertSlider' );
                                         this.editor.editing.view.focus();
                                     }}
+                                    onClickDisabled={() => this.editor.editing.view.focus()}
                                     {...{name: 'Slider'}}
                                 />
                                 <input
@@ -773,11 +788,13 @@ class ContentEditor extends Component {
                                         this.editor.execute( 'imageUpload', {file: e.target.files[0]} );
                                         this.editor.editing.view.focus();
                                     }}
+                                    onClickDisabled={() => this.editor.editing.view.focus()}
                                 />
                                 <ContentPartPreview
                                     key="imageUpload"
                                     enabled={false}
                                     onClick={this.showFileUpload}
+                                    onClickDisabled={() => this.editor.editing.view.focus()}
                                     {...{name: 'Image (Upload)'}}
                                 />
                                 <ContentPartPreview
@@ -788,6 +805,7 @@ class ContentEditor extends Component {
                                         this.editor.execute( 'imageInsert', {source: url} );
                                         this.editor.editing.view.focus();
                                     }}
+                                    onClickDisabled={() => this.editor.editing.view.focus()}
                                     {...{name: 'Image (URL)'}}
                                 />
                             </ul>
@@ -799,6 +817,7 @@ class ContentEditor extends Component {
                                         this.editor.execute( 'insertRateThisModuleQuestion' );
                                         this.editor.editing.view.focus();
                                     }}
+                                    onClickDisabled={() => this.editor.editing.view.focus()}
                                     {...{name: 'Rate This Module'}}
                                 />
                             </ul>

--- a/app/javascript/components/ContentPartPreview.js
+++ b/app/javascript/components/ContentPartPreview.js
@@ -4,7 +4,11 @@ export default class ContentPartPreview extends React.Component {
     render() {
         return (
             <li
-                onClick={() => this.props.onClick( this.props.id )}
+                onClick={() => {
+                    this.props.enabled
+                        ? this.props.onClick(this.props.id)
+                        : this.props.onClickDisabled();
+                }}
                 title="Add to the editor"
                 className={this.props.enabled ? '' : 'disabled'}
             >


### PR DESCRIPTION
**Task**: https://app.asana.com/0/1170776727341290/1169251338691091

**Test**
- Insert section, radio question, click into label
- Try clicking greyed out buttons in `Insert Component`
- Verify that nothing happens, e.g. prompt for rows/columns when you click `Insert Table` and that focus stays in the label area

**Details**
- If the button is disabled, don't run the `onClick` event handler. 
- But we don't want to loose focus on the element the designer was editing previously, so we need to still execute the focus event. 
- The `onClickDisabled()` handler has to be a lambda so the code isn't evaluated when the component is instantiated and only run when clicked. E.g., I said `onClickDisabled=this.editor.editing.view.focus}` would be equivalent, but that's not true because it tries to evaluate when `this.editor` is uninitialized and still `null` and I get a runtime error.
- Callback handler here instead of passing `this.editor` was a choice so that `ContentPartPreview` knows as little about CKEditor as possible. 