### PR TITLE
Render HTML on the show page

### DIFF
--- a/app/assets/stylesheets/course_contents.scss
+++ b/app/assets/stylesheets/course_contents.scss
@@ -3,6 +3,16 @@
 // You can use Sass (SCSS) here: http://sass-lang.com/
 /* assets/styles.css */
 
+/* --- Show module --- */
+.show-module-notice {
+        margin: 2em;
+	font-size: 20px;
+
+	strong {
+                color: red;
+	}
+}
+
 /* --- Editor / Content styles --- */
 .bz-module,
 .bz-view-box {

--- a/app/assets/stylesheets/course_contents.scss
+++ b/app/assets/stylesheets/course_contents.scss
@@ -5,11 +5,11 @@
 
 /* --- Show module --- */
 .show-module-notice {
-        margin: 2em;
 	font-size: 20px;
+	margin: 2em;
 
 	strong {
-                color: red;
+		color: red;
 	}
 }
 

--- a/app/views/course_contents/show.html.erb
+++ b/app/views/course_contents/show.html.erb
@@ -1,24 +1,7 @@
-<p id="notice"><%= notice %></p>
+<p class="show-module-notice"><strong>Note</strong>: This is not how this page will look on Canvas.
+To view this page on canvas, you must publish it from the
+<%= link_to 'editor', edit_course_content_path(@course_content) %>.
 
-<p>
-  <strong>Title:</strong>
-  <%= @course_content.title %>
-</p>
-
-<p>
-  <strong>Body:</strong>
-  <%= @course_content.body %>
-</p>
-
-<p>
-  <strong>Published at:</strong>
-  <%= @course_content.published_at %>
-</p>
-
-<p>
-  <strong>Type:</strong>
-  <%= @course_content.content_type %>
-</p>
-
-<%= link_to 'Edit', edit_course_content_path(@course_content) %> |
-<%= link_to 'Back', course_contents_path %>
+<div class="<%= @course_content.content_type == 'wiki_page' ? 'bz-module' : 'bz-assignment' %>">
+  <%== @course_content.body %>
+</div>

--- a/app/views/course_contents/show.html.erb
+++ b/app/views/course_contents/show.html.erb
@@ -1,5 +1,5 @@
 <p class="show-module-notice"><strong>Note</strong>: This is not how this page will look on Canvas.
-To view this page on canvas, you must publish it from the
+To view this page on Canvas, you must publish it from the
 <%= link_to 'editor', edit_course_content_path(@course_content) %>.
 
 <div class="<%= @course_content.content_type == 'wiki_page' ? 'bz-module' : 'bz-assignment' %>">

--- a/spec/views/course_contents/show.html.erb_spec.rb
+++ b/spec/views/course_contents/show.html.erb_spec.rb
@@ -14,12 +14,13 @@ RSpec.describe "course_contents/show", type: :view do
     expect(rendered).to match(/<p>MyText<\/p>/)
   end
 
-  it "adds appropriate div class for content_type" do
-    # module first
+  it "adds appropriate div class for module" do
     render
     expect(rendered).to match(/<div class="bz-module">/)
+  end
 
-    # then assignment
+
+  it "adds appropriate div class for assignment" do
     assign(:course_content, CourseContent.create!(
       :title => "Title",
       :body => "<p>MyText</p>",

--- a/spec/views/course_contents/show.html.erb_spec.rb
+++ b/spec/views/course_contents/show.html.erb_spec.rb
@@ -2,17 +2,30 @@ require 'rails_helper'
 
 RSpec.describe "course_contents/show", type: :view do
   before(:each) do
-    @course_content = assign(:course_content, CourseContent.create!(
+    assign(:course_content, CourseContent.create!(
       :title => "Title",
-      :body => "MyText",
-      :content_type => "MyText"
+      :body => "<p>MyText</p>",
+      :content_type => "wiki_page"
     ))
   end
 
-  it "renders attributes in <p>" do
+  it "renders HTML" do
     render
-    expect(rendered).to match(/Title/)
-    expect(rendered).to match(/MyText/)
-    expect(rendered).to match(/MyText/)
+    expect(rendered).to match(/<p>MyText<\/p>/)
+  end
+
+  it "adds appropriate div class for content_type" do
+    # module first
+    render
+    expect(rendered).to match(/<div class="bz-module">/)
+
+    # then assignment
+    assign(:course_content, CourseContent.create!(
+      :title => "Title",
+      :body => "<p>MyText</p>",
+      :content_type => "assignment"
+    ))
+    render
+    expect(rendered).to match(/<div class="bz-assignment">/)
   end
 end


### PR DESCRIPTION
Task: none

Summary: Renders HTML in the `show` page, to make it easier for me to download the full HTML without having to unescape a bunch of characters or something. I did this now so I can get the HTML from the modules on prod and clean up the duplicate-tooltip-span mess.

Screenshot: 
<img width="878" alt="Screen Shot 2020-04-23 at 10 16 14 AM" src="https://user-images.githubusercontent.com/1382374/80116356-7c240c00-854b-11ea-8a49-3294acbce91a.png">
