### PR TITLE
Implement icons as data attribute

### DIFF
--- a/app/assets/stylesheets/course_contents.scss
+++ b/app/assets/stylesheets/course_contents.scss
@@ -69,6 +69,19 @@
     color: #a54c2a;
 }
 
+
+div.module-block div.module-icon-preview,
+.module-icon-preview {
+        width: 50px;
+        height: 50px;
+        background-position-y: 0;
+        padding: 0;
+        border: 0;
+        margin: 0;
+        margin-bottom: 0.5em;
+        background-repeat: no-repeat;
+}
+
 /* TYPOGRAPHY */
 body {
 	font-family: Georgia, serif;

--- a/app/javascript/ckeditor/blockquotecontentediting.js
+++ b/app/javascript/ckeditor/blockquotecontentediting.js
@@ -35,38 +35,6 @@ export default class BlockquoteContentEditing extends Plugin {
         const conversion = editor.conversion;
         const { editing, data, model } = editor;
 
-        // <blockquoteContent> converters
-        conversion.for( 'upcast' ).elementToElement( {
-            view: {
-                name: 'div',
-                classes: ['module-block', 'block-quote-bg']
-            },
-            model: ( viewElement, modelWriter ) => {
-                // Read the "data-id" attribute from the view and set it as the "id" in the model.
-                return modelWriter.createElement( 'blockquoteContent' );
-            }
-        } );
-        conversion.for( 'dataDowncast' ).elementToElement( {
-            model: 'blockquoteContent',
-            view: ( modelElement, viewWriter ) => {
-                return viewWriter.createEditableElement( 'div', {
-                    'class': 'module-block block-quote-bg',
-                } );
-
-            }
-        } );
-        conversion.for( 'editingDowncast' ).elementToElement( {
-            model: 'blockquoteContent',
-            view: ( modelElement, viewWriter ) => {
-
-                const blockquoteContent = viewWriter.createContainerElement( 'div', {
-                    'class': 'module-block block-quote-bg',
-                } );
-
-                return toWidget( blockquoteContent, viewWriter, { label: 'blockquote widget' } );
-            }
-        } );
-
         // <blockquoteQuote> converters
         conversion.for( 'upcast' ).elementToElement( {
             model: 'blockquoteQuote',

--- a/app/javascript/ckeditor/blockquotecontentediting.js
+++ b/app/javascript/ckeditor/blockquotecontentediting.js
@@ -19,12 +19,6 @@ export default class BlockquoteContentEditing extends Plugin {
     _defineSchema() {
         const schema = this.editor.model.schema;
 
-        schema.register( 'blockquoteContent', {
-            isObject: true,
-            allowIn: 'section',
-            allowAttributes: [ 'class' ]
-        } );
-
         schema.register( 'blockquoteQuote', {
             allowIn: 'content',
             allowContentOf: '$root'

--- a/app/javascript/ckeditor/contentcommonediting.js
+++ b/app/javascript/ckeditor/contentcommonediting.js
@@ -34,7 +34,7 @@ export default class ContentCommonEditing extends Plugin {
         // Shared elements.
         schema.register( 'content', {
             isObject: true,
-            allowIn: [ 'blockquoteContent', 'tableContent', 'iframeContent', 'videoContent' ],
+            allowIn: [ 'moduleBlock' ],
             allowContentOf: '$root'
         });
 
@@ -53,7 +53,7 @@ export default class ContentCommonEditing extends Plugin {
 
         schema.register( 'question', {
             isObject: true,
-            allowIn: [ 'checklistQuestion', 'radioQuestion', 'matchingQuestion', 'matrixQuestion' ],
+            allowIn: [ 'moduleBlock' ],
             allowAttributes: [ 'data-instant-feedback', 'data-mastery', 'data-grade-as' ]
         } );
 
@@ -105,7 +105,7 @@ export default class ContentCommonEditing extends Plugin {
 
         schema.register( 'answer', {
             isObject: true,
-            allowIn: [ 'checklistQuestion', 'radioQuestion', 'matchingQuestion', 'matrixQuestion' ]
+            allowIn: [ 'moduleBlock' ]
         } );
 
         schema.register( 'answerTitle', {

--- a/app/javascript/ckeditor/insertblockquotecontentcommand.js
+++ b/app/javascript/ckeditor/insertblockquotecontentcommand.js
@@ -21,10 +21,7 @@ export default class InsertBlockquoteContentCommand extends Command {
 function createBlockquoteContent( writer ) {
     const blockquoteContent = writer.createElement(
         'moduleBlock',
-        {
-            'blockClasses': 'module-block module-block-quote',
-            'data-icon': 'module-block-quote',
-        },
+        { 'blockClasses': 'module-block block-quote-bg' },
     );
     const content = writer.createElement( 'content' );
     const quote = writer.createElement( 'blockquoteQuote' );

--- a/app/javascript/ckeditor/insertblockquotecontentcommand.js
+++ b/app/javascript/ckeditor/insertblockquotecontentcommand.js
@@ -12,14 +12,14 @@ export default class InsertBlockquoteContentCommand extends Command {
     refresh() {
         const model = this.editor.model;
         const selection = model.document.selection;
-        const allowedIn = model.schema.findAllowedParent( selection.getFirstPosition(), 'blockquoteContent' );
+        const allowedIn = model.schema.findAllowedParent( selection.getFirstPosition(), 'moduleBlock' );
 
         this.isEnabled = allowedIn !== null;
     }
 }
 
 function createBlockquoteContent( writer ) {
-    const blockquoteContent = writer.createElement( 'blockquoteContent' );
+    const blockquoteContent = writer.createElement( 'moduleBlock', {blockClasses: 'module-block module-block-quote'} );
     const content = writer.createElement( 'content' );
     const quote = writer.createElement( 'blockquoteQuote' );
     const paragraph = writer.createElement( 'paragraph' );

--- a/app/javascript/ckeditor/insertblockquotecontentcommand.js
+++ b/app/javascript/ckeditor/insertblockquotecontentcommand.js
@@ -19,7 +19,13 @@ export default class InsertBlockquoteContentCommand extends Command {
 }
 
 function createBlockquoteContent( writer ) {
-    const blockquoteContent = writer.createElement( 'moduleBlock', {blockClasses: 'module-block module-block-quote'} );
+    const blockquoteContent = writer.createElement(
+        'moduleBlock',
+        {
+            'blockClasses': 'module-block module-block-quote',
+            'data-icon': 'module-block-quote',
+        },
+    );
     const content = writer.createElement( 'content' );
     const quote = writer.createElement( 'blockquoteQuote' );
     const paragraph = writer.createElement( 'paragraph' );

--- a/app/javascript/ckeditor/insertcontentblockcommand.js
+++ b/app/javascript/ckeditor/insertcontentblockcommand.js
@@ -1,7 +1,7 @@
 import Command from '@ckeditor/ckeditor5-core/src/command';
 
 export default class InsertContentBlockCommand extends Command {
-    execute( classes='module-block module-block-reflection' ) {
+    execute( classes='module-block' ) {
         this.editor.model.change( writer => {
             const { contentBlock, selection } = createContentBlock( writer, classes );
             this.editor.model.insertContent( contentBlock );
@@ -19,7 +19,13 @@ export default class InsertContentBlockCommand extends Command {
 }
 
 function createContentBlock( writer, classes ) {
-    const contentBlock = writer.createElement( 'moduleBlock', { 'class': classes } );
+    const contentBlock = writer.createElement(
+        'moduleBlock',
+        {
+            'class': classes,
+            'data-icon':'module-block-reflection',
+        },
+    );
     const content = writer.createElement( 'content' );
     const contentTitle = writer.createElement( 'contentTitle' );
     const contentBody = writer.createElement( 'contentBody' );

--- a/app/javascript/ckeditor/insertmatchingquestioncommand.js
+++ b/app/javascript/ckeditor/insertmatchingquestioncommand.js
@@ -13,7 +13,7 @@ export default class InsertMatchingQuestionCommand extends Command {
         //const insertPosition = findOptimalInsertionPosition( selection, model );
 
         this.editor.model.change( writer => {
-            const matchingQuestion = writer.createElement( 'matchingQuestion' );
+            const matchingQuestion = writer.createElement( 'moduleBlock' );
             const question = writer.createElement( 'question', {'data-grade-as': 'matching'} );
             const questionTitle = writer.createElement( 'questionTitle' );
             const questionBody = writer.createElement( 'questionBody' );
@@ -67,7 +67,7 @@ export default class InsertMatchingQuestionCommand extends Command {
     refresh() {
         const model = this.editor.model;
         const selection = model.document.selection;
-        const allowedIn = model.schema.findAllowedParent( selection.getFirstPosition(), 'matchingQuestion' );
+        const allowedIn = model.schema.findAllowedParent( selection.getFirstPosition(), 'moduleBlock' );
 
         this.isEnabled = allowedIn !== null;
     }

--- a/app/javascript/ckeditor/insertmatrixquestioncommand.js
+++ b/app/javascript/ckeditor/insertmatrixquestioncommand.js
@@ -12,14 +12,14 @@ export default class InsertMatrixQuestionCommand extends Command {
     refresh() {
         const model = this.editor.model;
         const selection = model.document.selection;
-        const allowedIn = model.schema.findAllowedParent( selection.getFirstPosition(), 'matrixQuestion' );
+        const allowedIn = model.schema.findAllowedParent( selection.getFirstPosition(), 'moduleBlock' );
 
         this.isEnabled = allowedIn !== null;
     }
 }
 
 function createMatrixQuestion( writer, options ) {
-    const matrixQuestion = writer.createElement( 'matrixQuestion' );
+    const matrixQuestion = writer.createElement( 'moduleBlock' );
     const question = writer.createElement( 'question', {'data-grade-as': 'matrix'} );
     const questionTitle = writer.createElement( 'questionTitle' );
     const questionBody = writer.createElement( 'questionBody' );

--- a/app/javascript/ckeditor/insertsliderquestioncommand.js
+++ b/app/javascript/ckeditor/insertsliderquestioncommand.js
@@ -10,14 +10,14 @@ export default class InsertSliderQuestionCommand extends Command {
     refresh() {
         const model = this.editor.model;
         const selection = model.document.selection;
-        const allowedIn = model.schema.findAllowedParent( selection.getFirstPosition(), 'sliderQuestion' );
+        const allowedIn = model.schema.findAllowedParent( selection.getFirstPosition(), 'moduleBlock' );
 
         this.isEnabled = allowedIn !== null;
     }
 }
 
 function createSliderQuestion( writer ) {
-    const sliderQuestion = writer.createElement( 'sliderQuestion' );
+    const sliderQuestion = writer.createElement( 'moduleBlock' );
     const question = writer.createElement( 'question', { 'data-grade-as': 'range' } );
     const questionTitle = writer.createElement( 'questionTitle' );
     const questionBody = writer.createElement( 'questionBody' );

--- a/app/javascript/ckeditor/inserttablecontentcommand.js
+++ b/app/javascript/ckeditor/inserttablecontentcommand.js
@@ -10,7 +10,7 @@ export default class InsertTableCommand extends Command {
         const columns = parseInt( options.columns ) || 2;
 
         this.editor.model.change( writer => {
-            const tableContent = writer.createElement( 'tableContent' );
+            const tableContent = writer.createElement( 'moduleBlock' );
             const content = writer.createElement( 'content' );
             const contentTitle = writer.createElement( 'contentTitle' );
             const contentBody = writer.createElement( 'contentBody' );
@@ -29,7 +29,7 @@ export default class InsertTableCommand extends Command {
     refresh() {
         const model = this.editor.model;
         const selection = model.document.selection;
-        const allowedIn = model.schema.findAllowedParent( selection.getFirstPosition(), 'tableContent' );
+        const allowedIn = model.schema.findAllowedParent( selection.getFirstPosition(), 'moduleBlock' );
 
         this.isEnabled = allowedIn !== null;
     }

--- a/app/javascript/ckeditor/inserttextareaquestioncommand.js
+++ b/app/javascript/ckeditor/inserttextareaquestioncommand.js
@@ -10,14 +10,14 @@ export default class InsertTextAreaQuestionCommand extends Command {
     refresh() {
         const model = this.editor.model;
         const selection = model.document.selection;
-        const allowedIn = model.schema.findAllowedParent( selection.getFirstPosition(), 'textAreaQuestion' );
+        const allowedIn = model.schema.findAllowedParent( selection.getFirstPosition(), 'moduleBlock' );
 
         this.isEnabled = allowedIn !== null;
     }
 }
 
 function createTextAreaQuestion( writer ) {
-    const textAreaQuestion = writer.createElement( 'textAreaQuestion' );
+    const textAreaQuestion = writer.createElement( 'moduleBlock' );
     const question = writer.createElement( 'question', { 'data-grade-as': 'textarea' } );
     const questionTitle = writer.createElement( 'questionTitle' );
     const questionBody = writer.createElement( 'questionBody' );

--- a/app/javascript/ckeditor/insertvideocontentcommand.js
+++ b/app/javascript/ckeditor/insertvideocontentcommand.js
@@ -10,14 +10,14 @@ export default class InsertVideoContentCommand extends Command {
     refresh() {
         const model = this.editor.model;
         const selection = model.document.selection;
-        const allowedIn = model.schema.findAllowedParent( selection.getFirstPosition(), 'videoContent' );
+        const allowedIn = model.schema.findAllowedParent( selection.getFirstPosition(), 'moduleBlock' );
 
         this.isEnabled = allowedIn !== null;
     }
 }
 
 function createVideoContent( writer, url ) {
-    const videoContent = writer.createElement( 'videoContent' );
+    const videoContent = writer.createElement( 'moduleBlock', {blockClasses: 'module-block module-block-video'} );
     const content = writer.createElement( 'content' );
     const contentTitle = writer.createElement( 'contentTitle' );
     const contentBody = writer.createElement( 'contentBody' );

--- a/app/javascript/ckeditor/insertvideocontentcommand.js
+++ b/app/javascript/ckeditor/insertvideocontentcommand.js
@@ -17,7 +17,13 @@ export default class InsertVideoContentCommand extends Command {
 }
 
 function createVideoContent( writer, url ) {
-    const videoContent = writer.createElement( 'moduleBlock', {blockClasses: 'module-block module-block-video'} );
+    const videoContent = writer.createElement(
+        'moduleBlock',
+        {
+            'blockClasses': 'module-block',
+            'data-icon': 'module-block-video',
+        },
+    );
     const content = writer.createElement( 'content' );
     const contentTitle = writer.createElement( 'contentTitle' );
     const contentBody = writer.createElement( 'contentBody' );

--- a/app/javascript/ckeditor/matchingquestionediting.js
+++ b/app/javascript/ckeditor/matchingquestionediting.js
@@ -32,11 +32,6 @@ export default class MatchingQuestionEditing extends Plugin {
     _defineSchema() {
         const schema = this.editor.model.schema;
 
-        schema.register( 'matchingQuestion', {
-            isObject: true,
-            allowIn: 'section',
-        } );
-
         schema.register( 'matchingTable', {
             isObject: true,
             allowIn: 'question',
@@ -75,37 +70,6 @@ export default class MatchingQuestionEditing extends Plugin {
         const editor = this.editor;
         const conversion = editor.conversion;
         const { editing, data, model } = editor;
-
-        // <matchingQuestion> converters
-        conversion.for( 'upcast' ).elementToElement( {
-            view: {
-                name: 'div',
-                classes: ['module-block', 'module-block-matching']
-            },
-            model: ( viewElement, modelWriter ) => {
-                return modelWriter.createElement( 'matchingQuestion' );
-            }
-        } );
-        conversion.for( 'dataDowncast' ).elementToElement( {
-            model: 'matchingQuestion',
-            view: ( modelElement, viewWriter ) => {
-                return viewWriter.createEditableElement( 'div', {
-                    'class': 'module-block module-block-matching',
-                } );
-            }
-        } );
-        conversion.for( 'editingDowncast' ).elementToElement( {
-            model: 'matchingQuestion',
-            view: ( modelElement, viewWriter ) => {
-                const id = modelElement.getAttribute( 'id' );
-
-                const matchingQuestion = viewWriter.createContainerElement( 'div', {
-                    'class': 'module-block module-block-matching',
-                } );
-
-                return toWidget( matchingQuestion, viewWriter, { label: 'matching-question widget' } );
-            }
-        } );
 
         // <matchingTable> converters
         conversion.for( 'upcast' ).elementToElement( {

--- a/app/javascript/ckeditor/matrixquestionediting.js
+++ b/app/javascript/ckeditor/matrixquestionediting.js
@@ -11,7 +11,6 @@ export default class MatrixQuestionEditing extends Plugin {
 
     init() {
         this._defineSchema();
-        this._defineConverters();
 
         this.editor.commands.add( 'insertMatrixQuestion', new InsertMatrixQuestionCommand( this.editor ) );
     }
@@ -19,49 +18,8 @@ export default class MatrixQuestionEditing extends Plugin {
     _defineSchema() {
         const schema = this.editor.model.schema;
 
-        schema.register( 'matrixQuestion', {
-            isObject: true,
-            allowIn: 'section',
-        } );
-
         schema.extend( 'table', {
             allowIn: 'questionFieldset',
         } );
-    }
-
-    _defineConverters() {
-        const editor = this.editor;
-        const conversion = editor.conversion;
-        const { editing, data, model } = editor;
-
-        // <matrixQuestion> converters
-        conversion.for( 'upcast' ).elementToElement( {
-            view: {
-                name: 'div',
-                classes: [ 'module-block', 'module-block-matrix' ]
-            },
-            model: ( viewElement, modelWriter ) => {
-                return modelWriter.createElement( 'matrixQuestion' );
-            }
-        } );
-        conversion.for( 'dataDowncast' ).elementToElement( {
-            model: 'matrixQuestion',
-            view: ( modelElement, viewWriter ) => {
-                return viewWriter.createEditableElement( 'div', {
-                    'class': 'module-block module-block-matrix',
-                } );
-            }
-        } );
-        conversion.for( 'editingDowncast' ).elementToElement( {
-            model: 'matrixQuestion',
-            view: ( modelElement, viewWriter ) => {
-                const matrixQuestion = viewWriter.createContainerElement( 'div', {
-                    'class': 'module-block module-block-matrix',
-                } );
-
-                return toWidget( matrixQuestion, viewWriter, { label: 'matrix-question widget' } );
-            }
-        } );
-
     }
 }

--- a/app/javascript/ckeditor/moduleblockediting.js
+++ b/app/javascript/ckeditor/moduleblockediting.js
@@ -79,6 +79,7 @@ export default class ModuleBlockEditing extends Plugin {
             model: ( viewElement, modelWriter ) => {
                 return modelWriter.createElement( 'moduleBlock', {
                     'blockClasses': viewElement.getAttribute('class') || 'module-block',
+                    'data-icon': viewElement.getAttribute('data-icon') || 'module-block-question',
                 });
             }
         } );

--- a/app/javascript/ckeditor/moduleblockediting.js
+++ b/app/javascript/ckeditor/moduleblockediting.js
@@ -60,7 +60,7 @@ export default class ModuleBlockEditing extends Plugin {
             allowAttributes: [
                 // FIXME: Camelcase is broken with CKE built-in conversions, esp. on upcast
                 'blockClasses',
-                'icon',
+                'data-icon',
             ],
         } );
     }
@@ -101,6 +101,6 @@ export default class ModuleBlockEditing extends Plugin {
             }
         } );
 
-        conversion.attributeToAttribute( { model: 'icon', view: 'icon' } );
+        conversion.attributeToAttribute( { model: 'data-icon', view: 'data-icon' } );
     }
 }

--- a/app/javascript/ckeditor/moduleblockediting.js
+++ b/app/javascript/ckeditor/moduleblockediting.js
@@ -57,7 +57,11 @@ export default class ModuleBlockEditing extends Plugin {
         schema.register( 'moduleBlock', {
             isObject: true,
             allowIn: 'section',
-            allowAttributes: [ 'blockClasses' ],
+            allowAttributes: [
+                // FIXME: Camelcase is broken with CKE built-in conversions, esp. on upcast
+                'blockClasses',
+                'icon',
+            ],
         } );
     }
 
@@ -95,28 +99,8 @@ export default class ModuleBlockEditing extends Plugin {
 
                 return toWidget( moduleBlock, viewWriter, { label: 'module-block widget', hasSelectionHandle: true } );
             }
-        } ).add( dispatcher => {
-            // We need an additional attribute converter on the editingDowncast to update the module-block
-            // class live in the editing view when it's changed by setAttributes. For some reason,
-            // attributeToAttribute doesn't work with classes, so we use the lower-level event dispatcher.
-            // See https://github.com/bebraven/platform/pull/172 if we have a chance to look into this more
-            // later.
-            dispatcher.on( 'attribute', ( evt, data, conversionApi ) => {
-                // Ignore everything but the 'blockClasses' model attribute.
-                if ( data.attributeKey !== 'blockClasses' ) {
-                    return;
-                }
-
-                const viewWriter = conversionApi.writer;
-                const viewElement = conversionApi.mapper.toViewElement( data.item );
-
-                // In the model-to-view conversion we convert changes.
-                // An attribute can be added or removed or changed.
-                // The below code only handles adding/removing, because we don't want to delete the class.
-                if ( data.attributeNewValue ) {
-                    viewWriter.setAttribute( 'class', data.attributeNewValue, viewElement );
-                }
-            } );
         } );
+
+        conversion.attributeToAttribute( { model: 'icon', view: 'icon' } );
     }
 }

--- a/app/javascript/ckeditor/moduleblockediting.js
+++ b/app/javascript/ckeditor/moduleblockediting.js
@@ -5,7 +5,6 @@ import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import Widget from '@ckeditor/ckeditor5-widget/src/widget';
 import { toWidget } from '@ckeditor/ckeditor5-widget/src/utils';
 
-
 export default class ModuleBlockEditing extends Plugin {
     static get requires() {
         return [ Widget, Clipboard ];
@@ -58,7 +57,7 @@ export default class ModuleBlockEditing extends Plugin {
         schema.register( 'moduleBlock', {
             isObject: true,
             allowIn: 'section',
-            allowAttribute: [ 'blockClasses' ],
+            allowAttributes: [ 'blockClasses' ],
         } );
 
         // Allow question, answer, and content divs inside module-block divs.

--- a/app/javascript/ckeditor/moduleblockediting.js
+++ b/app/javascript/ckeditor/moduleblockediting.js
@@ -59,19 +59,6 @@ export default class ModuleBlockEditing extends Plugin {
             allowIn: 'section',
             allowAttributes: [ 'blockClasses' ],
         } );
-
-        // Allow question, answer, and content divs inside module-block divs.
-        schema.extend( 'question', {
-            allowIn: [ 'moduleBlock' ],
-        } );
-
-        schema.extend( 'answer', {
-            allowIn: [ 'moduleBlock' ],
-        } );
-
-        schema.extend( 'content', {
-            allowIn: [ 'moduleBlock' ],
-        } );
     }
 
     _defineConverters() {
@@ -108,6 +95,23 @@ export default class ModuleBlockEditing extends Plugin {
 
                 return toWidget( moduleBlock, viewWriter, { label: 'module-block widget', hasSelectionHandle: true } );
             }
+        } ).add( dispatcher => {
+            dispatcher.on( 'attribute', ( evt, data, conversionApi ) => {
+                // Allow all elements in the model to have any of a preset list of attributes.
+                if ( data.attributeKey !== 'blockClasses' ) {
+                    return;
+                }
+
+                const viewWriter = conversionApi.writer;
+                const viewElement = conversionApi.mapper.toViewElement( data.item );
+
+                // In the model-to-view conversion we convert changes.
+                // An attribute can be added or removed or changed.
+                // The below code only handles adding/removing, because we don't want to delete the class.
+                if ( data.attributeNewValue ) {
+                    viewWriter.setAttribute( 'class', data.attributeNewValue, viewElement );
+                }
+            } );
         } );
     }
 }

--- a/app/javascript/ckeditor/moduleblockediting.js
+++ b/app/javascript/ckeditor/moduleblockediting.js
@@ -77,9 +77,26 @@ export default class ModuleBlockEditing extends Plugin {
                 classes: ['module-block']
             },
             model: ( viewElement, modelWriter ) => {
+                // Get existing classes on the element
+                const srcClasses = viewElement.getAttribute('class') || 'module-block';
+
+                // We need special handling for icon because it was originally set in 
+                // <div class=...> and we're now keeping track of it in <div data-icon=...>
+                const icon = (
+                    // The data-icon attribute was already set on the element
+                    viewElement.getAttribute('data-icon')
+                    // The icon was in the element's class list
+                    || srcClasses.split(" ").find( c => c.startsWith('module-block-') )
+                    // Nothing was specified, use a default
+                    || 'module-block-question'
+                );
+
+                // Remove icon from class
+                const blockClasses = srcClasses.replace(icon, "").trim();
+
                 return modelWriter.createElement( 'moduleBlock', {
-                    'blockClasses': viewElement.getAttribute('class') || 'module-block',
-                    'data-icon': viewElement.getAttribute('data-icon') || 'module-block-question',
+                    'blockClasses': blockClasses,
+                    'data-icon': icon,
                 });
             }
         } );

--- a/app/javascript/ckeditor/moduleblockediting.js
+++ b/app/javascript/ckeditor/moduleblockediting.js
@@ -96,8 +96,13 @@ export default class ModuleBlockEditing extends Plugin {
                 return toWidget( moduleBlock, viewWriter, { label: 'module-block widget', hasSelectionHandle: true } );
             }
         } ).add( dispatcher => {
+            // We need an additional attribute converter on the editingDowncast to update the module-block
+            // class live in the editing view when it's changed by setAttributes. For some reason,
+            // attributeToAttribute doesn't work with classes, so we use the lower-level event dispatcher.
+            // See https://github.com/bebraven/platform/pull/172 if we have a chance to look into this more
+            // later.
             dispatcher.on( 'attribute', ( evt, data, conversionApi ) => {
-                // Allow all elements in the model to have any of a preset list of attributes.
+                // Ignore everything but the 'blockClasses' model attribute.
                 if ( data.attributeKey !== 'blockClasses' ) {
                     return;
                 }

--- a/app/javascript/ckeditor/sliderquestionediting.js
+++ b/app/javascript/ckeditor/sliderquestionediting.js
@@ -18,11 +18,6 @@ export default class SliderQuestionEditing extends Plugin {
     _defineSchema() {
         const schema = this.editor.model.schema;
 
-        schema.register( 'sliderQuestion', {
-            isObject: true,
-            allowIn: 'section',
-        } );
-
         schema.register( 'displayValueDiv', {
             isObject: true,
             allowIn: 'questionFieldset',
@@ -41,14 +36,6 @@ export default class SliderQuestionEditing extends Plugin {
             allowContentOf: [ '$block' ],
         } );
 
-        schema.extend( 'question', {
-            allowIn: 'sliderQuestion'
-        } );
-
-        schema.extend( 'answer', {
-            allowIn: 'sliderQuestion'
-        } );
-
         schema.extend( 'slider', {
             allowIn: 'questionFieldset'
         } );
@@ -58,35 +45,6 @@ export default class SliderQuestionEditing extends Plugin {
         const editor = this.editor;
         const conversion = editor.conversion;
         const { editing, data, model } = editor;
-
-        // <sliderQuestion> converters
-        conversion.for( 'upcast' ).elementToElement( {
-            view: {
-                name: 'div',
-                classes: ['module-block', 'module-block-range']
-            },
-            model: ( viewElement, modelWriter ) => {
-                return modelWriter.createElement( 'sliderQuestion', {} );
-            }
-        } );
-        conversion.for( 'dataDowncast' ).elementToElement( {
-            model: 'sliderQuestion',
-            view: ( modelElement, viewWriter ) => {
-                return viewWriter.createContainerElement( 'div', {
-                    'class': 'module-block module-block-range',
-                } );
-            }
-        } );
-        conversion.for( 'editingDowncast' ).elementToElement( {
-            model: 'sliderQuestion',
-            view: ( modelElement, viewWriter ) => {
-                const sliderQuestion = viewWriter.createContainerElement( 'div', {
-                    'class': 'module-block module-block-range',
-                } );
-
-                return toWidget( sliderQuestion, viewWriter, { label: 'range question widget' } );
-            }
-        } );
 
         // <displayValueDiv> converters
         conversion.for( 'upcast' ).elementToElement( {

--- a/app/javascript/ckeditor/tablecontentediting.js
+++ b/app/javascript/ckeditor/tablecontentediting.js
@@ -10,7 +10,6 @@ export default class TableContentEditing extends Plugin {
 
     init() {
         this._defineSchema();
-        this._defineConverters();
 
         this.editor.commands.add( 'insertTableContent', new InsertTableContentCommand( this.editor ) );
     }
@@ -18,50 +17,8 @@ export default class TableContentEditing extends Plugin {
     _defineSchema() {
         const schema = this.editor.model.schema;
 
-        schema.register( 'tableContent', {
-            isObject: true,
-            allowIn: 'section'
-        } );
-
         schema.extend( 'slider', {
             allowIn: 'tableCell'
-        } );
-    }
-
-    _defineConverters() {
-        const editor = this.editor;
-        const conversion = editor.conversion;
-        const { editing, data, model } = editor;
-
-        // <tableContent> converters
-        conversion.for( 'upcast' ).elementToElement( {
-            view: {
-                name: 'div',
-                classes: ['module-block', 'module-block-table']
-            },
-            model: ( viewElement, modelWriter ) => {
-                return modelWriter.createElement( 'tableContent' );
-            }
-        } );
-        conversion.for( 'dataDowncast' ).elementToElement( {
-            model: 'tableContent',
-            view: ( modelElement, viewWriter ) => {
-                return viewWriter.createEditableElement( 'div', {
-                    'class': 'module-block module-block-table',
-                } );
-            }
-        } );
-        conversion.for( 'editingDowncast' ).elementToElement( {
-            model: 'tableContent',
-            view: ( modelElement, viewWriter ) => {
-                const id = modelElement.getAttribute( 'id' );
-
-                const tableContent = viewWriter.createContainerElement( 'div', {
-                    'class': 'module-block module-block-table',
-                } );
-
-                return toWidget( tableContent, viewWriter, { label: 'table widget' } );
-            }
         } );
     }
 }

--- a/app/javascript/ckeditor/textareaquestionediting.js
+++ b/app/javascript/ckeditor/textareaquestionediting.js
@@ -10,65 +10,7 @@ export default class TextAreaQuestionEditing extends Plugin {
     }
 
     init() {
-        this._defineSchema();
-        this._defineConverters();
-
         this.editor.commands.add( 'insertTextAreaQuestion', new InsertTextAreaQuestionCommand( this.editor ) );
         this.editor.commands.add( 'insertTextArea', new InsertTextAreaCommand( this.editor ) );
-    }
-
-    _defineSchema() {
-        const schema = this.editor.model.schema;
-
-        schema.register( 'textAreaQuestion', {
-            isObject: true,
-            allowIn: 'section'
-        } );
-
-        schema.extend( 'question', {
-            allowIn: 'textAreaQuestion'
-        } );
-
-        schema.addChildCheck( ( context, childDefinition ) => {
-            // Disallow adding questions inside answerText boxes.
-            if ( context.endsWith( 'answerText' ) && childDefinition.name == 'textAreaQuestion' ) {
-                return false;
-            }
-        } );
-    }
-
-    _defineConverters() {
-        const editor = this.editor;
-        const conversion = editor.conversion;
-        const { editing, data, model } = editor;
-
-        // <textAreaQuestion> converters
-        conversion.for( 'upcast' ).elementToElement( {
-            view: {
-                name: 'div',
-                classes: ['module-block', 'module-block-textarea']
-            },
-            model: ( viewElement, modelWriter ) => {
-                return modelWriter.createElement( 'textAreaQuestion' );
-            }
-        } );
-        conversion.for( 'dataDowncast' ).elementToElement( {
-            model: 'textAreaQuestion',
-            view: ( modelElement, viewWriter ) => {
-                return viewWriter.createEditableElement( 'div', {
-                    'class': 'module-block module-block-textarea',
-                } );
-            }
-        } );
-        conversion.for( 'editingDowncast' ).elementToElement( {
-            model: 'textAreaQuestion',
-            view: ( modelElement, viewWriter ) => {
-                const textAreaQuestion = viewWriter.createContainerElement( 'div', {
-                    'class': 'module-block module-block-textarea',
-                } );
-
-                return toWidget( textAreaQuestion, viewWriter, { label: 'textArea-question widget' } );
-            }
-        } );
     }
 }

--- a/app/javascript/ckeditor/videocontentediting.js
+++ b/app/javascript/ckeditor/videocontentediting.js
@@ -19,11 +19,6 @@ export default class VideoContentEditing extends Plugin {
     _defineSchema() {
         const schema = this.editor.model.schema;
 
-        schema.register( 'videoContent', {
-            isObject: true,
-            allowIn: 'section',
-        } );
-
         schema.register( 'videoFigure', {
             isObject: true,
             allowIn: [ 'content', 'question', '$root' ],

--- a/app/javascript/components/ContentEditor.js
+++ b/app/javascript/components/ContentEditor.js
@@ -462,7 +462,50 @@ class ContentEditor extends Component {
                         </div>
                         <div id="toolbar-contextual">
                             {this.state.modelPath.map( modelElement => {
-                                if ( ['textArea', 'textInput'].includes( modelElement ) ) {
+                                if ( ['moduleBlock'].includes( modelElement ) ) {
+                                    // Module-blocks have class settings.
+                                    let moduleBlock = getNamedAncestor( 'moduleBlock', this.state['selectedElement'] );
+                                    if ( this.state['selectedElement'].name === 'moduleBlock' ) {
+                                        moduleBlock = this.state['selectedElement'];
+                                    }
+
+                                    if (moduleBlock === undefined) {
+                                        // The selected element no longer has 'moduleBlock' as an ancestor - it was
+                                        // probably deleted. We can just return and let React re-render with the new
+                                        // selection.
+                                        return;
+                                    }
+
+                                    return (
+                                        <>
+                                            <h4>Module Block</h4>
+
+                                            <div className={"module-icon-wrapper " + moduleBlock.getAttribute('blockClasses')}>
+                                                <div
+                                                    className="module-icon-preview question"
+                                                />
+                                            </div>
+                                            <select
+                                                id='input-module-block-type'
+                                                defaultValue={moduleBlock.getAttribute('blockClasses')}
+                                                onChange={( evt ) => {
+                                                    this.editor.execute( 'setAttributes', { 'blockClasses': evt.target.value }, moduleBlock );
+                                                }}
+                                            >
+                                                <option value="module-block">Default</option>
+                                                <option value="module-block module-block-action">Action</option>
+                                                <option value="module-block module-block-alert">Alert</option>
+                                                <option value="module-block module-block-key">Key</option>
+                                                <option value="module-block module-block-pulse">Pulse</option>
+                                                <option value="module-block module-block-read">Read</option>
+                                                <option value="module-block module-block-reflection">Reflection</option>
+                                                <option value="module-block module-block-values">Values</option>
+                                                <option value="module-block module-block-video">Video</option>
+                                            </select>
+                                            <label htmlFor='input-module-block-type'>Block Icon</label>
+                                        </>
+                                    );
+                                } else if ( ['textArea', 'textInput'].includes( modelElement ) ) {
                                     // Text inputs and textareas have placeholder settings.
                                     return (
                                         <>

--- a/app/javascript/components/ContentEditor.js
+++ b/app/javascript/components/ContentEditor.js
@@ -475,32 +475,30 @@ class ContentEditor extends Component {
                                         // selection.
                                         return;
                                     }
-
                                     return (
                                         <>
                                             <h4>Module Block</h4>
 
-                                            <div className={"module-icon-wrapper " + moduleBlock.getAttribute('blockClasses')}>
-                                                <div
-                                                    className="module-icon-preview question"
-                                                />
+                                            <div className={"module-icon-wrapper module-block " + 
+                                                (moduleBlock.getAttribute('icon') || "module-block-question")}>
+                                                <div className="module-icon-preview question" />
                                             </div>
                                             <select
                                                 id='input-module-block-type'
-                                                defaultValue={moduleBlock.getAttribute('blockClasses')}
                                                 onChange={( evt ) => {
-                                                    this.editor.execute( 'setAttributes', { 'blockClasses': evt.target.value }, moduleBlock );
+                                                    this.editor.execute( 'setAttributes', { 'icon': evt.target.value }, moduleBlock );
                                                 }}
+                                                value={moduleBlock.getAttribute('icon') || "module-block-question"}
                                             >
-                                                <option value="module-block">Default</option>
-                                                <option value="module-block module-block-action">Action</option>
-                                                <option value="module-block module-block-alert">Alert</option>
-                                                <option value="module-block module-block-key">Key</option>
-                                                <option value="module-block module-block-pulse">Pulse</option>
-                                                <option value="module-block module-block-read">Read</option>
-                                                <option value="module-block module-block-reflection">Reflection</option>
-                                                <option value="module-block module-block-values">Values</option>
-                                                <option value="module-block module-block-video">Video</option>
+                                                <option value="module-block-question">Question</option>
+                                                <option value="module-block-action">Action</option>
+                                                <option value="module-block-alert">Alert</option>
+                                                <option value="module-block-key">Key</option>
+                                                <option value="module-block-pulse">Pulse</option>
+                                                <option value="module-block-read">Read</option>
+                                                <option value="module-block-reflection">Reflection</option>
+                                                <option value="module-block-values">Values</option>
+                                                <option value="module-block-video">Video</option>
                                             </select>
                                             <label htmlFor='input-module-block-type'>Block Icon</label>
                                         </>

--- a/app/javascript/components/ContentEditor.js
+++ b/app/javascript/components/ContentEditor.js
@@ -480,15 +480,15 @@ class ContentEditor extends Component {
                                             <h4>Module Block</h4>
 
                                             <div className={"module-icon-wrapper module-block " + 
-                                                (moduleBlock.getAttribute('icon') || "module-block-question")}>
+                                                (moduleBlock.getAttribute('data-icon') || "module-block-question")}>
                                                 <div className="module-icon-preview question" />
                                             </div>
                                             <select
                                                 id='input-module-block-type'
                                                 onChange={( evt ) => {
-                                                    this.editor.execute( 'setAttributes', { 'icon': evt.target.value }, moduleBlock );
+                                                    this.editor.execute( 'setAttributes', { 'data-icon': evt.target.value }, moduleBlock );
                                                 }}
-                                                value={moduleBlock.getAttribute('icon') || "module-block-question"}
+                                                value={moduleBlock.getAttribute('data-icon') || "module-block-question"}
                                             >
                                                 <option value="module-block-question">Question</option>
                                                 <option value="module-block-action">Action</option>


### PR DESCRIPTION
**Task**: https://app.asana.com/0/1170776727341290/1172273996801759

**Test**

**Without CSS changes, looking at `data-icon` attribute**
- Add `?debug` and use CKEditor inspector to check that `data-icon` gets set in Model and View
- Toggle between Design/Code tabs to make sure the change sticks in HTML
- Check upcast by adding new section, new checklist question, toggle to HTML, no `data-icon`, toggle back to Design to trigger upcast converter, toggle back to HTML, verify there's now a `data-icon=module-block-question`. (Sorry, this one was hard to describe. I can demo this if that makes it clearer!)

**With CSS changes**
- Manually change `new_bravenui.css` in Chrome inspector to: https://github.com/beyond-z/canvas-lms-js-css/pull/296
- Check that icon updates now when we use the selector
- Check that we can still select the widget after changing icon
- Check that we can Ctrl+Z to undo icon change
- Save and Publish to Portal, again pasting in CSS changes, verify that the icon attribute made it through and renders

<img width="1139" alt="Screen Shot 2020-05-06 at 1 07 38 PM" src="https://user-images.githubusercontent.com/62911934/81223981-cec5e500-8f9b-11ea-8ed4-4bceb0a48930.png">
<img width="1138" alt="Screen Shot 2020-05-06 at 1 07 46 PM" src="https://user-images.githubusercontent.com/62911934/81223986-cff71200-8f9b-11ea-8548-808836d3ea3d.png">
<img width="1135" alt="Screen Shot 2020-05-06 at 1 10 39 PM" src="https://user-images.githubusercontent.com/62911934/81223988-d1283f00-8f9b-11ea-8005-9e6d1454e157.png">


**Details**
- This is based on Ryan's PR https://github.com/bebraven/platform/pull/172. The first 4 commits here are all Ryan's code that I `cherry-pick`ed and built on top of. 
- CKE has known issues when you try to modify `class`. In the above PR, everything worked except for the `setAttribute('class', ...)` in this commit: https://github.com/bebraven/platform/pull/176/commits/fecda75f27a74fd13ae4d7493a0159cd9be53609
- For some reason, it prevents CKE from adding `ck-widget_with_selection_handle`, which means as soon as you change the icon, you couldn't select the question as a widget anymore.
- Instead of trying to do `<div class='module-block module-block{icon}'>`, we'll do it `<div class='module-class' icon='module-block-{action, ...}'` and save the icon chosen with the `icon` data attribute. 
- This will require CSS changes in `beyond-z/canvas-lms-js-css/new_bravenui.css`: https://github.com/beyond-z/canvas-lms-js-css/pull/296
- `camelCase` attributes appear to interact poorly with CKEditor's attribute conversion helpers, I spent a ton of time figuring out why things like `iconClass` didn't work but `blockClasses` did.
