### PR TITLE
Moving CSS content editor hacks to only impact that form.

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -32,32 +32,6 @@
        unicode-range: U+0020-2122;
 }
 
-/* custom temporary hacks for content editor demo */
-form {
-  height: 100%;
-}
-
-div.field {
-  height: 100%;
-}
-
-div.field > div {
-  height: 100%;
-}
-div#raw-html-container > textarea {
-  width: 100%;
-  min-height: 400px;
-}
-.ck.ck-editor__editable_inline {
-  min-height: 370px;
-}
-span#autosave-indicator {
-  display: none;
-}
-textarea.secret-html {
-  display: none;
-}
-/* /hacks */
 
 body {
   font-size: .875rem;

--- a/app/assets/stylesheets/course_contents.scss
+++ b/app/assets/stylesheets/course_contents.scss
@@ -3,6 +3,35 @@
 // You can use Sass (SCSS) here: http://sass-lang.com/
 /* assets/styles.css */
 
+
+/* custom temporary hacks for content editor demo */
+#content-editor form {
+  height: 100%;
+}
+
+#content-editor div.field {
+  height: 100%;
+}
+
+#content-editor div.field > div {
+  height: 100%;
+}
+
+#content-editor div#raw-html-container > textarea {
+  width: 100%;
+  min-height: 400px;
+}
+#content-editor .ck.ck-editor__editable_inline {
+  min-height: 370px;
+}
+#content-editor span#autosave-indicator {
+  display: none;
+}
+#content-editor textarea.secret-html {
+  display: none;
+}
+/* /hacks */
+
 /* --- Show module --- */
 .show-module-notice {
 	font-size: 20px;

--- a/app/views/course_contents/_form.html.erb
+++ b/app/views/course_contents/_form.html.erb
@@ -5,7 +5,7 @@
     courseContents: @course_contents
 }) %>
 
-<%= form_with(model: course_content, local: true) do |form| %>
+<%= form_with(model: course_content, id: 'content-editor', local: true) do |form| %>
 
   <% if course_content.errors.any? %>
     <div id="error_explanation">


### PR DESCRIPTION
I'm working on new account creation forms and these hacks where
conflicting with my stuff. I'll leave it up for a future "for real"
fix, but for now I'm just making them content editor specific.