### PR TITLE
Add textInput button, fix textArea/Input placeholders

### DIFF
--- a/app/javascript/components/ContentEditor.js
+++ b/app/javascript/components/ContentEditor.js
@@ -771,11 +771,21 @@ class ContentEditor extends Component {
                                     key="insertTextArea"
                                     enabled={this.state.enabledCommands.includes('insertTextArea')}
                                     onClick={( id ) => {
-                                        this.editor.execute( 'insertTextArea' );
+                                        this.editor.execute( 'insertTextArea', '' );
                                         this.editor.editing.view.focus();
                                     }}
                                     onClickDisabled={() => this.editor.editing.view.focus()}
                                     {...{name: 'Text Area'}}
+                                />
+                                <ContentPartPreview
+                                    key="insertTextInput"
+                                    enabled={this.state.enabledCommands.includes('insertTextInput')}
+                                    onClick={( id ) => {
+                                        this.editor.execute( 'insertTextInput', '' );
+                                        this.editor.editing.view.focus();
+                                    }}
+                                    onClickDisabled={() => this.editor.editing.view.focus()}
+                                    {...{name: 'Text Input'}}
                                 />
                                 <ContentPartPreview
                                     key="insertSlider"


### PR DESCRIPTION
Two changes:

1. Add a textInput button (the command already existed).
2. Set the default placeholder for both textInput/textArea to the empty string `''`, to fix the following 2 issues:
  a. When inserting a textarea/input, the default placeholder shows up as the literal string `undefined`.
  b. When attempting to edit the default placeholder, the editor crashes, and undo breaks.

Button Task: https://app.asana.com/0/1170776727341290/1173719663284395/f
Placeholder Task: https://app.asana.com/0/1170776727341290/1173719663284397/f