### PR TITLE
Highlight invalid things inside sections, and disallow adding all but a single module-block to sections.

### DIFF
--- a/app/assets/stylesheets/course_contents.scss
+++ b/app/assets/stylesheets/course_contents.scss
@@ -42,6 +42,25 @@
 	}
 }
 
+/* --- Warnings for invalid content --- */
+.content-section > :not(.module-block):not([data-placeholder="[Empty section]"]):before,
+.content-section > .module-block:nth-of-type(2):before {
+        content: "INVALID CONTENT IN SECTION \A";
+        white-space: pre;
+        color: black;
+        background-color: red;
+        border: 1px black solid;
+        padding: 0.2em;
+        font-weight: bold;
+        font-size: 12pt;
+        font-family: sans-serif;
+}
+
+.content-section > :not(.module-block):not([data-placeholder="[Empty section]"]),
+.content-section > .module-block:nth-of-type(2) {
+        background-color: khaki;
+}
+
 /* --- Editor / Content styles --- */
 .bz-module,
 .bz-view-box {

--- a/app/assets/stylesheets/course_contents.scss
+++ b/app/assets/stylesheets/course_contents.scss
@@ -45,7 +45,7 @@
 /* --- Warnings for invalid content --- */
 .content-section > :not(.module-block):not([data-placeholder="[Empty section]"]):before,
 .content-section > .module-block:nth-of-type(2):before {
-        content: "INVALID CONTENT IN SECTION \A";
+        content: "INVALID CONTENT IN SECTION - Please remove or ask tech team for help\A";
         white-space: pre;
         color: black;
         background-color: red;

--- a/app/javascript/ckeditor/insertsectioncommand.js
+++ b/app/javascript/ckeditor/insertsectioncommand.js
@@ -1,9 +1,22 @@
 import Command from '@ckeditor/ckeditor5-core/src/command';
+import { getNamedAncestor } from './utils';
 
 export default class InsertSectionCommand extends Command {
     execute() {
         this.editor.model.change( writer => {
-            this.editor.model.insertContent( createSection( writer ) );
+            const selection = this.editor.model.document.selection;
+            const position = selection.getFirstPosition();
+
+            const section = getNamedAncestor( 'section', position );
+            if ( section ) {
+                // IFF we're not in the root, before inserting, modify the current
+                // selection to after the section.
+                writer.setSelection( section, 'after' );
+            }
+
+            const newSection = createSection( writer );
+            this.editor.model.insertContent( newSection );
+            writer.setSelection( newSection, 'in' );
         } );
     }
 

--- a/app/javascript/ckeditor/insertsectioncommand.js
+++ b/app/javascript/ckeditor/insertsectioncommand.js
@@ -16,6 +16,14 @@ export default class InsertSectionCommand extends Command {
 
             const newSection = createSection( writer );
             this.editor.model.insertContent( newSection );
+
+            // HACK: If there's nothing after this section, append a paragraph, to
+            // allow typing outside of the section. If we don't do this check first,
+            // we might end up with a bunch of paragraphs instead of just one.
+            if ( !newSection.nextSibling ) {
+                writer.insertElement( 'paragraph', newSection, 'after' );
+            }
+
             writer.setSelection( newSection, 'in' );
         } );
     }

--- a/app/javascript/ckeditor/sectionediting.js
+++ b/app/javascript/ckeditor/sectionediting.js
@@ -25,7 +25,6 @@ export default class SectionEditing extends Plugin {
             // Handle two cases: moduleBlock is selected, or cursor is in a paragraph inside the section.
             if ( ( selectedElement && selectedElement.name === 'moduleBlock' ) ||
                     ( positionParent.parent && positionParent.parent.name === 'section' ) ) {
-                console.log(data.domEvent);
                 if ( data.domEvent.key === 'Enter' ) {
                     // On Enter, add a new section.
                     this.editor.execute( 'insertSection' )

--- a/app/javascript/ckeditor/sectionediting.js
+++ b/app/javascript/ckeditor/sectionediting.js
@@ -14,6 +14,34 @@ export default class SectionEditing extends Plugin {
         this._defineConverters();
 
         this.editor.commands.add( 'insertSection', new InsertSectionCommand( this.editor ) );
+
+        // Override the default keydown behavior to disallow adding anything but a single
+        // moduleBlock inside a section.
+        this.listenTo( this.editor.editing.view.document, 'keydown', ( evt, data ) => {
+            const selection = this.editor.model.document.selection;
+            const positionParent = selection.getLastPosition().parent;
+            const selectedElement = selection.getSelectedElement();
+
+            // Handle two cases: moduleBlock is selected, or cursor is in a paragraph inside the section.
+            if ( ( selectedElement && selectedElement.name === 'moduleBlock' ) ||
+                    ( positionParent.parent && positionParent.parent.name === 'section' ) ) {
+                console.log(data.domEvent);
+                if ( data.domEvent.key === 'Enter' ) {
+                    // On Enter, add a new section.
+                    this.editor.execute( 'insertSection' )
+                    data.preventDefault();
+                    evt.stop();
+                } else if ( !( data.domEvent.metaKey || data.domEvent.ctrlKey ) &&
+                        ![ 'Backspace', 'Delete' ].includes( data.domEvent.key ) ) {
+                    // Ignore most other keydowns, excluding control sequences and deletions.
+                    // This sucks, but hopefully it's good enough until we drop sections.
+                    data.preventDefault();
+                    evt.stop();
+                }
+            }
+        // Use 'highest' priority, because Widget._onKeydown listens at 'high'.
+        // https://github.com/ckeditor/ckeditor5-widget/blob/bdeec63534d11a4fa682bb34990c698435bc13e3/src/widget.js#L92
+        }, { priority: 'highest' } );
     }
 
     _defineSchema() {


### PR DESCRIPTION
Problem: The module JS expects sections to only have one module-block and nothing else. The booster content has many things inside sections. This causes the done-button JS to break and show everything inside the section.

Proposal: Highlight things that are invalid inside a section, to encourage the designer to fix them. I didn't enforce this from CKE because it doesn't seem possible from [addChildCheck](https://ckeditor.com/docs/ckeditor5/latest/api/module_engine_model_schema-Schema.html#function-addChildCheck), and I don't know another good place to put it.

Proposal part 2 (2020-05-07): Fix remaining pain points, without invalidating/mangling existing incorrect content. Additions as follows - 

* Disallow typing within sections. (Still allows ctrl-z/{ctrl-shift-z,ctrl-y}, backspace/delete, clipboard actions, etc.)
* Hitting enter within a section now creates a new section, instead of inserting a paragraph inside the section.
* Hitting enter inside a section with a module-block selected now creates a new section, instead of inserting a paragraph inside the section.
* The above makes it impossible for a designer to add multiple module-blocks inside a section, or to add paragraphs/headings/etc inside the section.
* If there is existing incorrect content, it will be highlighted by the CSS change, but the designer should never be able to create new incorrect content.

Pros:

* This solution takes minimal effort on our part; no digging around in CKE to figure out how to enforce this.
* Designers can easily tell what is invalid.

Cons:

* ~~The only way to add a new section while you're in a section that already has a module-block is to hit enter (which will show an alert for invalid `p` inside section), then click Section (which will show another alert as there are now two `p`s inside section), then click a Question/Content button (which will still show an alert above the newly inserted content, because of the remaining `p`). This may be confusing.~~ I fixed this.

Screenshot:

<img width="634" alt="Screen Shot 2020-05-04 at 2 12 26 PM" src="https://user-images.githubusercontent.com/1382374/81003980-50d5d280-8e11-11ea-995d-6c421652274a.png">

A better way to do this would be to get rid of sections entirely, but that would take more work and testing.

Sections task: https://app.asana.com/0/1170776727341290/1172766526299174/f
Done button task: https://app.asana.com/0/1170776727341290/1173524622792753/f