### PR TITLE
Allow adding done buttons to content blocks

### DIFF
--- a/app/javascript/ckeditor/contentcommonediting.js
+++ b/app/javascript/ckeditor/contentcommonediting.js
@@ -448,7 +448,7 @@ export default class ContentCommonEditing extends Plugin {
         conversion.for( 'dataDowncast' ).elementToElement( {
             model: 'doneButton',
             view: ( modelElement, viewWriter ) => {
-                return viewWriter.createContainerElement( 'input', {
+                return viewWriter.createEmptyElement( 'input', {
                     'type': 'button',
                     'value': 'Done',
                     'class': 'done-button',
@@ -460,7 +460,7 @@ export default class ContentCommonEditing extends Plugin {
         conversion.for( 'editingDowncast' ).elementToElement( {
             model: 'doneButton',
             view: ( modelElement, viewWriter ) => {
-                return viewWriter.createContainerElement( 'input', {
+                return viewWriter.createEmptyElement( 'input', {
                     'type': 'button',
                     'value': 'Done',
                     'class': 'done-button',

--- a/app/javascript/ckeditor/insertdonebuttoncommand.js
+++ b/app/javascript/ckeditor/insertdonebuttoncommand.js
@@ -1,24 +1,59 @@
 import Command from '@ckeditor/ckeditor5-core/src/command';
+import { getNamedChildOrSibling, getNamedAncestor } from './utils';
 
 export default class InsertDoneButtonCommand extends Command {
     execute() {
         this.editor.model.change( writer => {
-            const doneButton = createDoneButton( writer );
-            this.editor.model.insertContent( doneButton );
-            writer.setSelection( doneButton, 'on' );
+            // Note: This command only works in content blocks, not question or answer blocks.
+            // The selection is expected to be somewhere in or on the module-block.
+            // Before inserting, we must modify the current selection to the end of the content block.
+            const selection = this.editor.model.document.selection;
+            const selectedElement = selection.getSelectedElement();
+            const position = selection.getFirstPosition();
+
+            const contentBlock = findContentBlock( selectedElement, position );
+            if ( !contentBlock ) {
+                return;
+            }
+
+            writer.setSelection( contentBlock, 'end' );
+            this.editor.model.insertContent( createDoneButton( writer ) );
+
+            // ♪ Put that thing back where it came from, or so help meeee ♫
+            if ( selectedElement ) {
+                writer.setSelection( selectedElement, 'on' );
+            } else {
+                writer.setSelection( position );
+            }
         } );
     }
 
     refresh() {
         const model = this.editor.model;
         const selection = model.document.selection;
-        const allowedIn = model.schema.findAllowedParent( selection.getFirstPosition(), 'doneButton' );
+        const selectedElement = selection.getSelectedElement();
+        const position = selection.getFirstPosition();
+        const allowedIn = findContentBlock( selectedElement, position );
 
-        this.isEnabled = allowedIn !== null;
+        this.isEnabled = allowedIn !== undefined;
     }
 }
 
 function createDoneButton( writer ) {
     const doneButton = writer.createElement( 'doneButton' );
     return doneButton;
+}
+
+function findContentBlock( selectedElement, position ) {
+    // Find the content block.
+    let contentBlock;
+    if ( selectedElement && 'moduleBlock' === selectedElement.name ) {
+        // The current selection is a moduleBlock; check for a content block inside it.
+        contentBlock = getNamedChildOrSibling( 'content', selectedElement );
+
+    } else if ( contentBlock = getNamedAncestor( 'content', position ) ) {
+        // The cursor is inside the content block; we've already found it.
+    }
+
+    return contentBlock;
 }

--- a/app/javascript/ckeditor/utils.js
+++ b/app/javascript/ckeditor/utils.js
@@ -18,7 +18,7 @@ export function preventCKEditorHandling( domElement, editor ) {
 
 // Return the model element that is a parent of modelElement, with the model
 // name ancestorName. If there are multiple matching elements, return only the
-// topmost one.
+// topmost one. modelElement can also be a `Postition` inside the model.
 export function getNamedAncestor( ancestorName, modelElement ) {
     return modelElement.getAncestors().filter( x => { return x.name == ancestorName } )[0];
 }

--- a/app/javascript/components/ContentEditor.js
+++ b/app/javascript/components/ContentEditor.js
@@ -797,6 +797,16 @@ class ContentEditor extends Component {
                                     onClickDisabled={() => this.editor.editing.view.focus()}
                                     {...{name: 'Slider'}}
                                 />
+                                <ContentPartPreview
+                                    key="insertDoneButton"
+                                    enabled={this.state.enabledCommands.includes('insertDoneButton')}
+                                    onClick={( id ) => {
+                                        this.editor.execute( 'insertDoneButton' );
+                                        this.editor.editing.view.focus();
+                                    }}
+                                    onClickDisabled={() => this.editor.editing.view.focus()}
+                                    {...{name: 'Done Button'}}
+                                />
                                 <input
                                     type="file"
                                     style={{ display: "none" }}


### PR DESCRIPTION
Task: https://app.asana.com/0/1170776727341290/1172766526299157/f

Summary: Allow designers to add "Done" buttons to content blocks, but nowhere else.

Testing procedure:

* Load empty editor, note that "Done Button" button is disabled
* Insert section, note that "Done Button" button is disabled
* Insert question (any type), click around inside editor, note that "Done Button" button is always disabled
* Delete question, so you have an empty section again
* Insert "Text" content block (not "Text Area" or "Text Area Question")
* Note that "Done Button" button is enabled.
* Click around inside the text content-block, note that "Done Button" button remains enabled.
* Click on module-block so the border turns blue. 
  * Click "Done Button" button
  * Verify button is inserted at bottom of block.
  * Verify selection is returned to the module-block, so border turns blue.
* Click inside Content Title.
  * Click "Done Button" button
  * Verify button is inserted at bottom of block.
  * Verify selection is returned to the Content Title.
* Click inside Content Body.
  * Click "Done Button" button
  * Verify button is inserted at bottom of block.
  * Verify selection is returned to the Content Body.
* You should now have 3 done buttons.
* Undo, note the done buttons are removed.

Screenshots:

<img width="1241" alt="Screen Shot 2020-05-05 at 1 30 13 PM" src="https://user-images.githubusercontent.com/1382374/81102010-960f0880-8ed4-11ea-9902-2f0838504b95.png">
<img width="1241" alt="Screen Shot 2020-05-05 at 1 30 19 PM" src="https://user-images.githubusercontent.com/1382374/81102011-96a79f00-8ed4-11ea-873c-030c7ef0cd2e.png">
