### PR TITLE
Add checklist-other button

### DIFF
--- a/app/javascript/ckeditor/checklistquestionediting.js
+++ b/app/javascript/ckeditor/checklistquestionediting.js
@@ -5,6 +5,7 @@ import Widget from '@ckeditor/ckeditor5-widget/src/widget';
 import RetainedData from './retaineddata';
 import InsertChecklistQuestionCommand from './insertchecklistquestioncommand';
 import InsertCheckboxCommand from './insertcheckboxcommand';
+import InsertChecklistOtherCommand from './insertchecklistothercommand';
 import SetAttributesCommand from './setattributescommand';
 import { ALLOWED_ATTRIBUTES, filterAllowedAttributes } from './customelementattributepreservation';
 
@@ -19,6 +20,7 @@ export default class ChecklistQuestionEditing extends Plugin {
 
         this.editor.commands.add( 'insertChecklistQuestion', new InsertChecklistQuestionCommand( this.editor ) );
         this.editor.commands.add( 'insertCheckbox', new InsertCheckboxCommand( this.editor ) );
+        this.editor.commands.add( 'insertChecklistOther', new InsertChecklistOtherCommand( this.editor ) );
         this.editor.commands.add( 'setAttributes', new SetAttributesCommand( this.editor ) );
 
         // Add a shortcut to the retained data ID function.

--- a/app/javascript/ckeditor/insertchecklistothercommand.js
+++ b/app/javascript/ckeditor/insertchecklistothercommand.js
@@ -1,0 +1,62 @@
+import Command from '@ckeditor/ckeditor5-core/src/command';
+import { findAllowedParentIgnoreLimit, getNamedAncestor } from './utils';
+
+export default class InsertChecklistOtherCommand extends Command {
+    execute( placeholder ) {
+        this.editor.model.change( writer => {
+            // Before inserting, modify the current selection to after the checkboxDiv.
+            const selection = this.editor.model.document.selection;
+            const selectedElement = selection.getSelectedElement();
+            const position = selection.getFirstPosition();
+
+            // Find the checkboxDiv.
+            let checkboxDiv;
+            if ( selectedElement && selectedElement.name === 'checkboxDiv' ) {
+                // The current selection is a checkboxDiv.
+                checkboxDiv = selectedElement;
+            } else if ( [ 'checkboxLabel', 'checkboxInlineFeedback' ].includes(position.parent.name) ) {
+                // The cursor is inside one of the elements in the checkboxDiv, so find its ancestor checkboxDiv.
+                checkboxDiv = getNamedAncestor( 'checkboxDiv', position );
+            } else {
+                // In any other case, just return without doing anything.
+                // This makes us a bit more robust, in case we modify checkboxDiv later on.
+                return;
+            }
+            writer.setSelection( checkboxDiv, 'after' );
+            this.editor.model.insertContent( createChecklistOther( writer, placeholder ) );
+        } );
+    }
+
+    refresh() {
+        const model = this.editor.model;
+        const selection = model.document.selection;
+
+        // Explicitly ignore Limit behavior, because checkboxLabel is a limit.
+        // This feels hacky, but should be safe here.
+        const allowedIn = findAllowedParentIgnoreLimit( model.schema, selection.getFirstPosition(), 'checkboxDiv' );
+
+        this.isEnabled = allowedIn !== null;
+    }
+}
+
+function createChecklistOther( writer, placeholder ) {
+    const checkboxDiv = writer.createElement( 'checkboxDiv' );
+    const checkboxInput = writer.createElement( 'checkboxInput', {
+        'data-bz-optional-magic-field': true,
+        'data-correctness': 'maybe',
+    } );
+    const checkboxLabel = writer.createElement( 'checkboxLabel' );
+    const textArea = writer.createElement( 'textArea', {
+        placeholder,
+        'data-bz-optional-magic-field': true,
+    } );
+
+    writer.append( checkboxInput, checkboxDiv );
+    writer.append( checkboxLabel, checkboxDiv );
+    writer.append( textArea, checkboxDiv );
+
+    // Add text to empty editables where placeholders don't work.
+    writer.insertText( 'Other:', checkboxLabel );
+
+    return checkboxDiv;
+}

--- a/app/javascript/components/ContentEditor.js
+++ b/app/javascript/components/ContentEditor.js
@@ -543,6 +543,12 @@ class ContentEditor extends Component {
                                     }
                                     const inputElement = getNamedChildOrSibling( inputTypes[modelElement], this.state['selectedElement'] );
 
+                                    if (inputElement === undefined) {
+                                        // The selection changed out from under us!
+                                        // We can just return and let React re-render with the new selection.
+                                        return;
+                                    }
+
                                     return (
                                         <>
                                             <h4>Option</h4>
@@ -766,6 +772,16 @@ class ContentEditor extends Component {
                                     }}
                                     onClickDisabled={() => this.editor.editing.view.focus()}
                                     {...{name: 'IFrame'}}
+                                />
+                                <ContentPartPreview
+                                    key="insertChecklistOther"
+                                    enabled={this.state.enabledCommands.includes('insertChecklistOther')}
+                                    onClick={( id ) => {
+                                        this.editor.execute( 'insertChecklistOther', '' );
+                                        this.editor.editing.view.focus();
+                                    }}
+                                    onClickDisabled={() => this.editor.editing.view.focus()}
+                                    {...{name: '"Other" Checkbox with Text Area'}}
                                 />
                                 <ContentPartPreview
                                     key="insertTextArea"


### PR DESCRIPTION
Task: https://app.asana.com/0/1170776727341290/1172646780976523/f

Summary: Add an `"Other" Checkbox with Text Area` button, to let designers add "Other:" checkboxes to checklist questions.

Testing procedure:

1. Note the "Other" button is disabled
1. Insert section, insert checklist question
2. Click on/in the first checklist option; note the "Other" button changes to enabled
3. Click the "Other" button; verify a new option with a textarea is added after the currently selected option.

Other notes:

* "Other" options have no inline-feedback, by design.
* Both the checkbox `<input>` and the `<textarea>` will have the `data-bz-optional-magic-field="true"` attribute. This is used by the module JS as part of autograding.
* The "Other" checkbox will have `data-correctness` automatically set to `maybe`. ("Other" options are never right or wrong.)
* The "Other" textarea should not have a placeholder set.

Screenshots

<img width="1241" alt="Screen Shot 2020-05-05 at 2 20 19 PM" src="https://user-images.githubusercontent.com/1382374/81106669-9ced4980-8edb-11ea-8313-795e3c33a428.png">
<img width="1241" alt="Screen Shot 2020-05-05 at 2 20 36 PM" src="https://user-images.githubusercontent.com/1382374/81106671-9e1e7680-8edb-11ea-9a56-f53292a21e27.png">

