### PR TITLE
Adjust editor max-height for (right-sidebar) inflation

### DIFF
--- a/app/assets/stylesheets/course_contents.scss
+++ b/app/assets/stylesheets/course_contents.scss
@@ -265,7 +265,8 @@ section.content-section {
 }
 
 div#wysiwyg-container {
-    max-height: 672px;
+    // Set a max height that matches the right-sidebar... for now.
+    max-height: 825px;
     overflow-y: auto;
 }
 


### PR DESCRIPTION
No task, this was just annoying me.

Now the editor can get as tall as the right sidebar, if you have a lot of content. Makes it easier to click buttons.