### PR TITLE
Add admin for Booster to dummies.rb

### DIFF
--- a/db/dummies.rb
+++ b/db/dummies.rb
@@ -17,9 +17,16 @@ User.find_or_create_by email: 'admin@bebraven.org' do |u|
   u.confirmed_at = DateTime.now
   u.admin = true
 end
+User.find_or_create_by email: 'booster.admin@bebraven.org' do |u|
+ u.first_name = 'Dev'
+ u.last_name = 'Admin(Booster)'
+ u.password = "#{ENV['DEV_ENV_USER_PASSWORD']}"
+ u.confirmed_at = DateTime.now
+ u.admin = true
+end
 
 user_count = User.count
-FactoryBot.create_list(:registered_user, 5) unless user_count > 2
+FactoryBot.create_list(:registered_user, 5) unless user_count > 3
 puts "Created #{User.count - user_count} users"
 
 org = Organization.find_or_create_by! name: 'San Jose State University'


### PR DESCRIPTION
The admin account for Booster is different from the existing portal/staging ones. It's `booster.admin@bebraven.org` instead of `admin@{beyondz,bebraven}.org`. 

I ran into this because my local `canvasweb` uses Booster data fetched with `dbrefreshbooster.sh`. When I login to `canvasweb` with `admin@`, I get an error because that email doesn't exist in the Booster's user emails. 

Adding the Booster admin email `db/dummies.rb`, so after you `dbrefresh` , you can login. 