### PR TITLE
Refactor Sync To LMS and account creation to work with Salesforce Programs

### DIFF
--- a/app/controllers/salesforce_controller.rb
+++ b/app/controllers/salesforce_controller.rb
@@ -10,12 +10,12 @@ class SalesforceController < ApplicationController
     # Say it takes a minute or two to run, can we have Salesforce wait for the response?
     # If not, queue this up on the background and have a page listing recent runs and their status?
     # Send an email?
-    course_id = params[:course_id]
-    if course_id
-      SyncToLMS.new.execute(course_id) 
-      @user_notification = "Sync To LMS has been submitted for course #{course_id}"
+    program_id = params[:program_id]
+    if program_id
+      SyncToLMS.new.for_program(program_id) 
+      @user_notification = "Sync To LMS has been submitted for program #{program_id}"
     else
-      @user_notification = "Please enter the Course ID to sync below and hit Enter"
+      @user_notification = "Please enter the Program ID to sync below and hit Enter"
     end
      
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 require 'grade_calculator'
 require 'salesforce_api'
 require 'canvas_api'
+require 'sync_to_lms'
 
 class User < ApplicationRecord
   include Devise::Models::DatabaseAuthenticatable
@@ -125,8 +126,8 @@ class User < ApplicationRecord
     if existing_user
       self.canvas_id = existing_user['id']
     else
-      Rails.logger.error("User is trying to create an account but is not in Canvas: #{inspect}")
-      throw :abort # TODO: create them on the fly by running a Sync To LMS for just this user. Maybe it just wasn't run yet.
+      Rails.logger.info("Creating Canvas account and enrollments for new user: #{inspect}")
+      self.canvas_id = SyncToLMS.new.for_contact(salesforce_id)
     end
   end
 

--- a/app/views/salesforce/_form.html.erb
+++ b/app/views/salesforce/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with(url: salesforce_sync_to_lms_path, method: "post", local: true) do |form| %>
   <div class="field">
-    <%= form.label :course_id, "Course ID:" %>
-    <%= form.text_field :course_id %>
+    <%= form.label :program_id, "Program ID:" %>
+    <%= form.text_field :program_id %>
   </div>
 
   <div class="actions">

--- a/lib/canvas_api.rb
+++ b/lib/canvas_api.rb
@@ -36,20 +36,28 @@ class CanvasAPI
 
   def get(path, params={}, headers={})
     RestClient.get("#{@api_url}#{path}", {params: params}.merge(@global_headers.merge(headers)))
+  rescue => e
+    handle_rest_client_error(e)
   end
 
   def post(path, body, headers={})
     RestClient.post("#{@api_url}#{path}", body, @global_headers.merge(headers))
+  rescue => e
+    handle_rest_client_error(e)
   end
 
   def put(path, body, headers={})
     RestClient.put("#{@api_url}#{path}", body, @global_headers.merge(headers))
+  rescue => e
+    handle_rest_client_error(e)
   end
 
   def delete(path, body={}, headers={})
     # Delete helper method doesn't accept a payload. Have to drop down lower level.
     RestClient::Request.execute(method: :delete, 
       url: "#{@api_url}#{path}", payload: body, headers: @global_headers.merge(headers))
+  rescue => e
+    handle_rest_client_error(e)
   end
 
   def update_course_page(course_id, wiki_page_id, wiki_page_body)
@@ -97,6 +105,16 @@ class CanvasAPI
     types.each { |t| query_params += "&type[]=#{t}"}
     response = get("/courses/#{course_id}/enrollments?#{query_params}")
     get_all_from_pagination(response)
+  end
+
+  # Same as get_enrollments() but just for a single user
+  def get_user_enrollments(user_id, course_id=nil, types=[])
+    query_params = "per_page=100"
+    types.each { |t| query_params += "&type[]=#{t}"}
+    response = get("/users/#{user_id}/enrollments")
+    # TODO: if course_id is sent, filter the response to only include those for that course
+    enrollments = get_all_from_pagination(response)
+    (enrollments.blank? ? nil : enrollments) # No enrollments returns an empty array and nil is nicer to deal with.
   end
 
   # Enrolls the user in the new course, without modifying any existing data
@@ -183,5 +201,12 @@ class CanvasAPI
     # Return preview URL.
     info = JSON.parse(response.body)
     {url: "#{canvas_url}/courses/#{course_id}/files/#{info['id']}/preview"}
+
+  end
+
+  def handle_rest_client_error(e)
+    Rails.logger.error("{\"Error\":\"#{e.message}\"}")
+    Rails.logger.error(e.response.body)
+    raise
   end
 end

--- a/lib/tasks/salesforce.rake
+++ b/lib/tasks/salesforce.rake
@@ -1,13 +1,13 @@
 namespace :salesforce do
 
   desc 'Provision Enrolled Participants from Salesforce into Canvas'
-  # Example Usage: bundle exec rake salesforce:sync_to_lms[71]
-  task :sync_to_lms, [:course_id] => :environment do |_, args|
-    course_id = args[:course_id].to_i
-    puts("### Running Sync To LMS for #{course_id} - #{Time.now.strftime("%Y-%m-%d %H:%M:%S %Z")}")
+  # Example Usage: bundle exec rake salesforce:sync_to_lms[a2Y1J000000YpQFUA0]
+  task :sync_to_lms, [:program_id] => :environment do |_, args|
+    program_id = args[:program_id]
+    puts("### Running Sync To LMS for Program: #{program_id} - #{Time.now.strftime("%Y-%m-%d %H:%M:%S %Z")}")
     require 'sync_to_lms'
-    SyncToLMS.new.execute(course_id)
-    puts("    Done running Sync To LMS for #{course_id} - #{Time.now.strftime("%Y-%m-%d %H:%M:%S %Z")}")
+    SyncToLMS.new.for_program(program_id)
+    puts("    Done running Sync To LMS for Program: #{program_id} - #{Time.now.strftime("%Y-%m-%d %H:%M:%S %Z")}")
   end
 
 end

--- a/spec/factories/salesforce_participant.rb
+++ b/spec/factories/salesforce_participant.rb
@@ -6,7 +6,9 @@ FactoryBot.define do
     skip_create # This isn't stored in the DB.
 
     CandidateStatus { 'Fully Confirmed' }
+    sequence(:CohortScheduleDayTime) { |i| "TEST Mondays, #{i} pm" }
     sequence(:CohortName) { |i| "TEST Cohort#{i}" }
+    sequence(:ProgramId) { |i| "a2Y1700000#{i}WLxqAUX" }
     sequence(:ContactId) { |i| "a2Y1700000#{i}WLxqEAG" }
     sequence(:Email) { |i| "test#{i}@example.com" }
     sequence(:FirstName) { |i| "TestFirstName#{i}" }

--- a/spec/lib/salesforce_api_spec.rb
+++ b/spec/lib/salesforce_api_spec.rb
@@ -42,35 +42,51 @@ RSpec.describe SalesforceAPI do
     
   end
 
-  describe '#get_program_info(course_id)' do
+  describe '#get_program_info(program_id)' do
     let(:salesforce) { SalesforceAPI.client }
-    let(:course_id) { 71 }
+    let(:program_id) { '003170000125IpSAAU' }
 
     it 'calls the correct endpoint' do
       request_url_regex = /#{SALESFORCE_INSTANCE_URL}\/services\/data\/.*/
       program_json = FactoryBot.json(:salesforce_program)
       stub_request(:get, request_url_regex).to_return(body: program_json )
 
-      response = salesforce.get_program_info(course_id)
+      response = salesforce.get_program_info(program_id)
 
       expect(WebMock).to have_requested(:get, request_url_regex).once
       expect(response).to eq(JSON.parse(program_json)['records'][0])
     end
   end
 
-  describe '#get_participants(course_id)' do
+  describe '#get_participants()' do
     let(:salesforce) { SalesforceAPI.client }
-    let(:course_id) { 71 }
+    let(:program_id) { '003170000125IpSAAU' }
+    let(:contact_id) { '004170000125IpSAOX' }
 
-    it 'calls the correct endpoint' do
-      request_url = "#{SALESFORCE_INSTANCE_URL}/services/apexrest/participants/currentandfuture/?course_id=#{course_id}" 
-      participant_json = "[#{FactoryBot.json(:salesforce_participant_fellow)}]"
-      stub_request(:get, request_url).to_return(body: participant_json)
+    context 'with program_id only' do
+      it 'calls the correct endpoint' do
+        request_url = "#{SALESFORCE_INSTANCE_URL}/services/apexrest/participants/currentandfuture/?program_id=#{program_id}" 
+        participant_json = "[#{FactoryBot.json(:salesforce_participant_fellow)}]"
+        stub_request(:get, request_url).to_return(body: participant_json)
 
-      response = salesforce.get_participants(course_id)
+        response = salesforce.get_participants(program_id)
 
-      expect(WebMock).to have_requested(:get, request_url).once
-      expect(response).to eq(JSON.parse(participant_json))
+        expect(WebMock).to have_requested(:get, request_url).once
+        expect(response).to eq(JSON.parse(participant_json))
+      end
+    end
+
+    context 'with program_id and contact_id' do
+      it 'calls the correct endpoint' do
+        request_url = "#{SALESFORCE_INSTANCE_URL}/services/apexrest/participants/currentandfuture/?program_id=#{program_id}&contact_id=#{contact_id}" 
+        participant_json = "[#{FactoryBot.json(:salesforce_participant_fellow)}]"
+        stub_request(:get, request_url).to_return(body: participant_json)
+
+        response = salesforce.get_participants(program_id, contact_id)
+
+        expect(WebMock).to have_requested(:get, request_url).once
+        expect(response).to eq(JSON.parse(participant_json))
+      end
     end
   end
 


### PR DESCRIPTION
https://app.asana.com/0/1170770467635599/1173648174910505

We have two separate servers running the Portal, one for normal Braven and one
for Braven Booster. There may be conflicts with the course_id. Also, for Booster
we're going to have a "Holding" Program and then split folks out into Program's
specific to the run of the program they're taking. Also, folks may sign-up last
minute and we need to provision their account in Canvas. Lastly, Booster folks will not
be mapped to a Cohort. They will have a scheduled day/time and we need to add them
into Canvas in corresponding sections.

This commit aims to solve all that.

In addition to making Sync To LMS run off the Salesforce Program, it also changes
the account creation / sign_up to create their Canvas account on the fly at the time they
register their account. This was last minute sign-ups will work without running the sync.

Test Plan:
- `bundle exec rspec spec`
- Fully confirm and enroll a Participant in a Salesforce Program. Try signing up using their
  Contact Id and notice that they get Canvas access.
- Ditto but run Sync To LMS with the Program and see that they get Canvas access and are provisioned in a section for their scheduled day/time. It can be run with something like:
 `bundle exec rake salesforce:sync_to_lms[a2Y1J000000YpQFUA0]`
