### PR TITLE
Update correctness selector when you click on an answer

### DIFF
--- a/app/javascript/components/ContentEditor.js
+++ b/app/javascript/components/ContentEditor.js
@@ -554,7 +554,7 @@ class ContentEditor extends Component {
                                             <h4>Option</h4>
                                             <select
                                                 id='input-correctness'
-                                                defaultValue={inputElement.getAttribute('data-correctness')}
+                                                value={inputElement.getAttribute('data-correctness') || ""}
                                                 onChange={( evt ) => {
                                                     this.editor.execute( 'setAttributes', { 'data-correctness': evt.target.value }, inputElement );
                                                 }}


### PR DESCRIPTION
**Task**: https://app.asana.com/0/1170776727341290/1159217855939646

**Test**
- Here's a `.mov` screen recording of the fix, but GitHub only allows me upload it as a `.zip`: [Screen Recording 2020-05-06 at 3.49.04 PM.mov.zip](https://github.com/bebraven/platform/files/4589840/Screen.Recording.2020-05-06.at.3.49.04.PM.mov.zip)
 
- Add new section, new checklist question
- Make three answers using "enter" to add them
- Change correctness to "Correct", "Incorrect", "Maybe"
- Click between the answers and observe the selector on the right updates

**Details**
- I think this is one of the issues covered by the Asana task and I think it's going to be easier to fix than we initially thought. 
