### PR TITLE
Rename module-block-quote => block-quote-bg

### DIFF
--- a/app/assets/stylesheets/course_contents.scss
+++ b/app/assets/stylesheets/course_contents.scss
@@ -146,7 +146,7 @@ button.ck.ck-button.ck-heading_h5 .ck-button__label {
 }
 
 /* more overrides */
-.module-block-quote > div.content,
+.block-quote-bg > div.content,
 div.content > blockquote {
         width: 100%;
 }
@@ -156,7 +156,7 @@ div.content > blockquote:focus > small {
         color: black;
         background: none;
 }
-div.module-block:not(.module-block-quote) blockquote {
+div.module-block:not(.block-quote-bg) blockquote {
         padding: 0 1.5em;
         margin: 0;
         border-left: none;

--- a/app/javascript/ckeditor/blockquotecontentediting.js
+++ b/app/javascript/ckeditor/blockquotecontentediting.js
@@ -45,7 +45,7 @@ export default class BlockquoteContentEditing extends Plugin {
         conversion.for( 'upcast' ).elementToElement( {
             view: {
                 name: 'div',
-                classes: ['module-block', 'module-block-quote']
+                classes: ['module-block', 'block-quote-bg']
             },
             model: ( viewElement, modelWriter ) => {
                 // Read the "data-id" attribute from the view and set it as the "id" in the model.
@@ -56,7 +56,7 @@ export default class BlockquoteContentEditing extends Plugin {
             model: 'blockquoteContent',
             view: ( modelElement, viewWriter ) => {
                 return viewWriter.createEditableElement( 'div', {
-                    'class': 'module-block module-block-quote',
+                    'class': 'module-block block-quote-bg',
                 } );
 
             }
@@ -66,7 +66,7 @@ export default class BlockquoteContentEditing extends Plugin {
             view: ( modelElement, viewWriter ) => {
 
                 const blockquoteContent = viewWriter.createContainerElement( 'div', {
-                    'class': 'module-block module-block-quote',
+                    'class': 'module-block block-quote-bg',
                 } );
 
                 return toWidget( blockquoteContent, viewWriter, { label: 'blockquote widget' } );


### PR DESCRIPTION
**Task**: This facilitates designers changing icons. This PR allows us to differentiate the block-quote styling class from icon classes. 

**Test**
- Add new section, insert quote, check that renders correctly:
<img width="1788" alt="Screen Shot 2020-05-07 at 11 00 54 AM" src="https://user-images.githubusercontent.com/62911934/81328794-5b32df00-9052-11ea-8d0a-80407a2b40b7.png">
(The left padding is wrong from the `canvas-lms-js-css` code. I'll put up a PR for that.)

- Also check the HTML:
<img width="1778" alt="Screen Shot 2020-05-07 at 11 01 01 AM" src="https://user-images.githubusercontent.com/62911934/81328823-65ed7400-9052-11ea-9dea-f36887a7ba7e.png">

- Publish to check Portal side:
<img width="1312" alt="Screen Shot 2020-05-07 at 11 01 30 AM" src="https://user-images.githubusercontent.com/62911934/81328664-23c43280-9052-11ea-91d4-e685fb765997.png">

- You can also paste this into the `Code` tab of the editor: https://pastebin.com/sZT93ZUH
 (there are a bunch of other content/question sections because I was worried about impacting that CSS). 

*Details*
- This is part of allowing designers to change icons. 
- We need to differentiate between `module-block-{quote, textarea}` classes, which represent different types of content blocks (and affect styling of the section) `module-block-{video, reflection}` that represent icons (and should change the icon). 
- For `module-block-quote`, instead of generating `<div class="module-block module-block-quote">`, generate `<div class="module-block block-quote-bg">`. 
- Make the corresponding updates to the code inserting quotes and the CSS that renders it. 