### PR TITLE
Add dont-mix to checklists with 'other' options

### DIFF
--- a/app/javascript/ckeditor/insertchecklistothercommand.js
+++ b/app/javascript/ckeditor/insertchecklistothercommand.js
@@ -24,6 +24,11 @@ export default class InsertChecklistOtherCommand extends Command {
             }
             writer.setSelection( checkboxDiv, 'after' );
             this.editor.model.insertContent( createChecklistOther( writer, placeholder ) );
+
+            // Checklists with "other" options always need the "dont-mix" class on the fieldset, so
+            // add that now.
+            const fieldset = getNamedAncestor( 'questionFieldset', position );
+            writer.setAttributes( {'class': 'dont-mix'}, fieldset );
         } );
     }
 


### PR DESCRIPTION
This is a detail I missed in #187. By default, the module JS shuffles the order of options in a checklist. To stop it, we add the `dont-mix` class on the `fieldset` surrounding the `checkboxDiv`s. Since "Other" options always have to be at the end, we always want `dont-mix` on checklists with "Other" options.

Task: https://app.asana.com/0/1170776727341290/1172646780976523/f