### PR TITLE
Fix Text Area and Text Input placeholder updating

### DIFF
--- a/app/javascript/components/ContentEditor.js
+++ b/app/javascript/components/ContentEditor.js
@@ -511,7 +511,7 @@ class ContentEditor extends Component {
                                             <input
                                                 type='text'
                                                 id='input-placeholder'
-                                                defaultValue={this.state['selectedElement'].getAttribute('placeholder')}
+                                                value={this.state['selectedElement'].getAttribute('placeholder')}
                                                 onChange={( evt ) => {
                                                     this.editor.execute( 'setAttributes', { 'placeholder': evt.target.value } );
                                                 }}


### PR DESCRIPTION
**Task**: N/A, following up on https://github.com/bebraven/platform/pull/192

**Test**
- Screencast: [test2.mov.zip](https://github.com/bebraven/platform/files/4596105/test2.mov.zip)
- New section, add "Text Area", "Text Input", type in different placeholder texts, click between them, see that it changes on the RHS

<img width="1080" alt="Screen Shot 2020-05-07 at 3 40 07 PM" src="https://user-images.githubusercontent.com/62911934/81351428-271ee480-9079-11ea-9e92-0fb0aa8cfc41.png">

<img width="1084" alt="Screen Shot 2020-05-07 at 3 40 12 PM" src="https://user-images.githubusercontent.com/62911934/81351435-2a19d500-9079-11ea-89d3-ade6be581ac3.png">

**Details**
- Going through these one at a time so I actually test them. There a whole bunch in `ContentEditor.js`, but they're straightforward to tackle so far. 
- When we use `defaultValue`, we're telling React to treat the component as "uncontrolled", which really is just "let the DOM handle it, React treat it as opaque." But we never generate a reference for the input, so React has no idea what in the DOM to update. This is the React documentation on it: https://reactjs.org/docs/uncontrolled-components.html#default-values
- So we use `value` instead, which we read out of the editor state and make it a "controlled" component: https://reactjs.org/docs/forms.html#controlled-components. Now React is happy and knows what to update. 
- Note the controlled component approach works because (1) the current selection and its `value` are tracked in `this.state` and (2) `setAttribute` called in `onChange` modifies `this.state` under the hood. So it matches the React pattern for controlled components, albeit through a lot of layers of indirection involving CKE. 
