### PR TITLE
HOTFIX: Add python2 as a dependency so the container can build again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apk add --update --no-cache \
     tzdata \
     libnotify \
     git \
+    python2 \
     vim
 
 COPY Gemfile* /usr/src/app/


### PR DESCRIPTION
Without this, `docker-compose build` fails: 

```
error /usr/src/app/node_modules/node-sass: Command failed.
Exit code: 1
Command: node scripts/build.js
Arguments:
Directory: /usr/src/app/node_modules/node-sass
Output:
Building: /usr/bin/node /usr/src/app/node_modules/node-gyp/bin/node-gyp.js rebuild --verbose --libsass_ext= --libsass_cflags= --libsass_ldflags= --libsass_library=
gyp info it worked if it ends with ok
gyp verb cli [
gyp verb cli   '/usr/bin/node',
gyp verb cli   '/usr/src/app/node_modules/node-gyp/bin/node-gyp.js',
gyp verb cli   'rebuild',
gyp verb cli   '--verbose',
gyp verb cli   '--libsass_ext=',
gyp verb cli   '--libsass_cflags=',
gyp verb cli   '--libsass_ldflags=',
gyp verb cli   '--libsass_library='
gyp verb cli ]
gyp info using node-gyp@3.8.0
gyp info using node@12.15.0 | linux | x64
gyp verb command rebuild []
gyp verb command clean []
gyp verb clean removing "build" directory
gyp verb command configure []
gyp verb check python checking for Python executable "python2" in the PATH
gyp verb `which` failed Error: not found: python2
gyp verb `which` failed     at getNotFoundError (/usr/src/app/node_modules/which/which.js:13:12)
gyp verb `which` failed     at F (/usr/src/app/node_modules/which/which.js:68:19)
gyp verb `which` failed     at E (/usr/src/app/node_modules/which/which.js:80:29)
gyp verb `which` failed     at /usr/src/app/node_modules/which/which.js:89:16
gyp verb `which` failed     at /usr/src/app/node_modules/isexe/index.js:42:5
gyp verb `which` failed     at /usr/src/app/node_modules/isexe/mode.js:8:5
gyp verb `which` failed     at FSReqCallback.oncomplete (fs.js:158:21)
gyp verb `which` failed  python2 Error: not found: python2
gyp verb `which` failed     at getNotFoundError (/usr/src/app/node_modules/which/which.js:13:12)
gyp verb `which` failed     at F (/usr/src/app/node_modules/which/which.js:68:19)
gyp verb `which` failed     at E (/usr/src/app/node_modules/which/which.js:80:29)
gyp verb `which` failed     at /usr/src/app/node_modules/which/which.js:89:16
gyp verb `which` failed     at /usr/src/app/node_modules/isexe/index.js:42:5
gyp verb `which` failed     at /usr/src/app/node_modules/isexe/mode.js:8:5
gyp verb `which` failed     at FSReqCallback.oncomplete (fs.js:158:21) {
gyp verb `which` failed   stack: 'Error: not found: python2\n' +
gyp verb `which` failed     '    at getNotFoundError (/usr/src/app/node_modules/which/which.js:13:12)\n' +
gyp verb `which` failed     '    at F (/usr/src/app/node_modules/which/which.js:68:19)\n' +
gyp verb `which` failed     '    at E (/usr/src/app/node_modules/which/which.js:80:29)\n' +
gyp verb `which` failed     '    at /usr/src/app/node_modules/which/which.js:89:16\n' +
gyp verb `which` failed     '    at /usr/src/app/node_modules/isexe/index.js:42:5\n' +
gyp verb `which` failed     '    at /usr/src/app/node_modules/isexe/mode.js:8:5\n' +
gyp verb `which` failed     '    at FSReqCallback.oncomplete (fs.js:158:21)',
gyp verb `which` failed   code: 'ENOENT'
gyp verb `which` failed }
gyp verb check python checking for Python executable "python" in the PATH
gyp verb `which` failed Error: not found: python
gyp verb `which` failed     at getNotFoundError (/usr/src/app/node_modules/which/which.js:13:12)
gyp verb `which` failed     at F (/usr/src/app/node_modules/which/which.js:68:19)
gyp verb `which` failed     at E (/usr/src/app/node_modules/which/which.js:80:29)
gyp verb `which` failed     at /usr/src/app/node_modules/which/which.js:89:16
gyp verb `which` failed     at /usr/src/app/node_modules/isexe/index.js:42:5
gyp verb `which` failed     at /usr/src/app/node_modules/isexe/mode.js:8:5
gyp verb `which` failed     at FSReqCallback.oncomplete (fs.js:158:21)
gyp verb `which` failed  python Error: not found: python
gyp verb `which` failed     at getNotFoundError (/usr/src/app/node_modules/which/which.js:13:12)
gyp verb `which` failed     at F (/usr/src/app/node_modules/which/which.js:68:19)
gyp verb `which` failed     at E (/usr/src/app/node_modules/which/which.js:80:29)
gyp verb `which` failed     at /usr/src/app/node_modules/which/which.js:89:16
gyp verb `which` failed     at /usr/src/app/node_modules/isexe/index.js:42:5
gyp verb `which` failed     at /usr/src/app/node_modules/isexe/mode.js:8:5
gyp verb `which` failed     at FSReqCallback.oncomplete (fs.js:158:21) {
gyp verb `which` failed   stack: 'Error: not found: python\n' +
gyp verb `which` failed     '    at getNotFoundError (/usr/src/app/node_modules/which/which.js:13:12)\n' +
gyp verb `which` failed     '    at F (/usr/src/app/node_modules/which/which.js:68:19)\n' +
gyp verb `which` failed     '    at E (/usr/src/app/node_modules/which/which.js:80:29)\n' +
gyp verb `which` failed     '    at /usr/src/app/node_modules/which/which.js:89:16\n' +
gyp verb `which` failed     '    at /usr/src/app/node_modules/isexe/index.js:42:5\n' +
gyp verb `which` failed     '    at /usr/src/app/node_modules/isexe/mode.js:8:5\n' +
gyp verb `which` failed     '    at FSReqCallback.oncomplete (fs.js:158:21)',
gyp verb `which` failed   code: 'ENOENT'
gyp verb `which` failed }
gyp ERR! configure error
gyp ERR! stack Error: Can't find Python executable "python", you can set the PYTHON env variable.
gyp ERR! stack     at PythonFinder.failNoPython (/usr/src/app/node_modules/node-gyp/lib/configure.js:484:19)
gyp ERR! stack     at PythonFinder.<anonymous> (/usr/src/app/node_modules/node-gyp/lib/configure.js:406:16)
gyp ERR! stack     at F (/usr/src/app/node_modules/which/which.js:68:16)
gyp ERR! stack     at E (/usr/src/app/node_modules/which/which.js:80:29)
gyp ERR! stack     at /usr/src/app/node_modules/which/which.js:89:16
gyp ERR! stack     at /usr/src/app/node_modules/isexe/index.js:42:5
gyp ERR! stack     at /usr/src/app/node_modules/isexe/mode.js:8:5
gyp ERR! stack     at FSReqCallback.oncomplete (fs.js:158:21)
gyp ERR! System Linux 4.19.76-linuxkit
gyp ERR! command "/usr/bin/node" "/usr/src/app/node_modules/node-gyp/bin/node-gyp.js" "rebuild" "--verbose" "--libsass_ext=" "--libsass_cflags=" "--libsass_ldflags=" "--libsass_library="
gyp ERR! cwd /usr/src/app/node_modules/node-sass
gyp ERR! node -v v12.15.0
gyp ERR! node-gyp -v v3.8.0
gyp ERR! not ok
Build failed with error code: 1
ERROR: Service 'platformweb' failed to build: The command '/bin/sh -c yarn install --check-files' returned a non-zero code: 1
```