### PR TITLE
Move yarn install from build to startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,6 @@ WORKDIR /usr/src/app
 ENV BUNDLE_PATH /gems
 
 RUN bundle install && cp Gemfile.lock /tmp
-RUN yarn install --check-files
 
 COPY . /usr/src/app/
 

--- a/Gemfile
+++ b/Gemfile
@@ -38,18 +38,20 @@ group :development do
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
 
-  gem 'guard-rails', require: false
-  gem 'guard-rspec', require: false
-  gem 'guard-livereload', require: false
+  # Require rack-livereload in development bc we use it in config/environments/development.rb.
+  gem 'rack-livereload', require: true
+
   gem 'libnotify', require: false
-  gem 'rack-livereload', require: false
-  gem 'guard-webpacker', require: false
   gem 'webpacker-react', "~> 1.0.0.beta.1"
-  gem 'guard-bundler', require: false
-  gem 'guard-yarn', require: false
   gem 'pry-rescue', require: false
   gem 'pry-stack_explorer', require: false
   gem 'rubocop', require: false
+  gem 'guard-bundler', require: false
+  gem 'guard-livereload', require: false
+  gem 'guard-rails', require: false
+  gem 'guard-rspec', require: false
+  gem 'guard-webpacker', require: false
+  gem 'guard-yarn', require: false
 end
 
 group :test do

--- a/README.md
+++ b/README.md
@@ -126,10 +126,9 @@ In rare cases, you may need to bypass docker-compose and use docker directly to 
 
     docker volume rm platform_db-platform
 
-If you change JavaScript dependencies, you may need to run `yarn` in the container:
+If you change JavaScript dependencies, you need to restart the container, so yarn runs:
 
     docker-compose down
-    docker-compose run platformweb yarn install --check-files
 
 In all cases, to bring the container back up after a rebuild, run:
 
@@ -271,7 +270,7 @@ CKEditor updates tend to have major breaking changes often, so be sure to test a
 
 Once the dependencies are updated, you will need to rebuild your container:
 
-    docker-compose build && docker-compose run platformweb yarn install --check-files
+    docker-compose build
 
 ### Accessibility testing
 

--- a/docker-compose/scripts/docker_compose_run.sh
+++ b/docker-compose/scripts/docker_compose_run.sh
@@ -36,6 +36,8 @@ else
     cp_built_lock_file
 fi
 
+# Run yarn. Must be BEFORE any rake/rails calls.
+yarn install --check-files
 
 # Migrate the db, if needed.
 bundle exec rake db:migrate


### PR DESCRIPTION
We never use the packages we install at build time, because of the `node-modules` volume that gets mounted over top of them. Move yarn to the start script instead.

Results: 

* Container build is much faster ✅ 
* Container is smaller ✅ 
* Startup is 7s slower (on subsequent runs) ❌ 
* Startup is more reliable (no more yarn check failures! auto-installs new JS packages on container restart!) ✅ 