### PR TITLE
Tables default to left-aligned text

### DIFF
--- a/app/assets/stylesheets/course_contents.scss
+++ b/app/assets/stylesheets/course_contents.scss
@@ -101,6 +101,10 @@ div.module-block div.module-icon-preview,
         background-repeat: no-repeat;
 }
 
+figure.table {
+        text-align: left;
+}
+
 /* TYPOGRAPHY */
 body {
 	font-family: Georgia, serif;


### PR DESCRIPTION
Tables default to left-aligned text when published to Portal, but are centered when displayed in the editor. This fixes that.

Task: None (noticed while working with Tess a while back)