### PR TITLE
Use px instead of % for image resize

### DIFF
--- a/app/javascript/components/ContentEditor.js
+++ b/app/javascript/components/ContentEditor.js
@@ -165,6 +165,7 @@ BalloonEditor.defaultConfig = {
         ]
     },
     image: {
+        resizeUnit: 'px',
         toolbar: [
             'imageStyle:full',
             'imageStyle:side',


### PR DESCRIPTION
task: https://app.asana.com/0/1170776727341290/1174569613518649/f

docs: https://ckeditor.com/docs/ckeditor5/latest/features/image.html#using-pixels-instead-of-percentage-width

before (`style="width:31.8%;"`):
<img width="523" alt="Screen Shot 2020-05-12 at 2 23 54 PM" src="https://user-images.githubusercontent.com/1382374/81736470-3f697780-945c-11ea-863b-70c189650c88.png">
<img width="523" alt="Screen Shot 2020-05-12 at 2 24 42 PM" src="https://user-images.githubusercontent.com/1382374/81736527-590abf00-945c-11ea-95f2-c7b877a5e42e.png">

after (`style="100px;"`):
<img width="523" alt="Screen Shot 2020-05-12 at 2 23 20 PM" src="https://user-images.githubusercontent.com/1382374/81736482-442e2b80-945c-11ea-9b8b-d5949607fece.png">
<img width="523" alt="Screen Shot 2020-05-12 at 2 25 14 PM" src="https://user-images.githubusercontent.com/1382374/81736600-6fb11600-945c-11ea-9c98-a3a25619ae60.png">
