### PR TITLE
Add easier way to troubleshoot issues in gems.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,3 +15,9 @@ node_modules
 public/assets/
 public/packs/
 
+# Specs/tests stuff
+coverage/
+
+# Bundler / gems stuff
+.bundle/config
+vendor/bundle/

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,10 @@ ENV NODE_ENV=${RAILS_ENV}
 
 WORKDIR /app
 
-ENV BUNDLE_PATH /gems
+ENV BUNDLE_PATH=/app/vendor/bundle
 
 COPY Gemfile Gemfile.lock /app/
-RUN bundle install && cp Gemfile.lock /tmp
+RUN bundle install --path vendor/bundle --jobs 4 && cp Gemfile.lock /tmp
 
 COPY . /app/
 

--- a/README.md
+++ b/README.md
@@ -244,15 +244,24 @@ Or, for example you can inspect one such as the `@current_user` by writing `inst
 
 We also have the pry and rescue gems so that you can break and debug code. Here is an example for how to debug
 a spec that is throwing an exception.
+
     bundle exec rescue rspec spec/a_failing_spec.rb --format documentation   
+
+See [this FANTASTIC article](https://supergood.software/a-ruby-gem-debugging-strategy/) for some general advice around
+debugging and troubleshooting things if you're new to RoR development.
+
+Of specific note, if you need to debug the code inside a gem, our gems are installed
+at `vendor/bundle` inside the container. If you attach to the container you can dig down in there and add a 
+`binding.pry` call or some logging inside the gem code. You have to restart the container for the change to be 
+picked up and if you make a mess of things and want to blow it away you need to remove the vendor-bundle volume using:
+
+    docker-compose down -v vendor-bundle
 
 For troubleshooting ckeditor-specific issues in the content editor, append '?debug' to the URL:
 
     http://platformweb/course_contents/new?debug
 
 That will attach the [CKEditor Inspector](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/development-tools.html#ckeditor-5-inspector).
-
-**TODO:** talk about pry and other dev and troubleshooting techniques.
 
 ### Development environment setup
 

--- a/README.md
+++ b/README.md
@@ -252,10 +252,12 @@ debugging and troubleshooting things if you're new to RoR development.
 
 Of specific note, if you need to debug the code inside a gem, our gems are installed
 at `vendor/bundle` inside the container. If you attach to the container you can dig down in there and add a 
-`binding.pry` call or some logging inside the gem code. You have to restart the container for the change to be 
+some logging inside the gem code. You have to restart the container for the change to be 
 picked up and if you make a mess of things and want to blow it away you need to remove the vendor-bundle volume using:
 
     docker-compose down -v vendor-bundle
+
+**NOTE:** pry doesn't currently work with our setup. Need to figure that out.
 
 For troubleshooting ckeditor-specific issues in the content editor, append '?debug' to the URL:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - /app/tmp
       - /app/log
       - node-modules:/app/node_modules
+      - vendor-bundle:/app/vendor/bundle
       - webpack-cache:/app/tmp/cache/webpacker
     depends_on:
       - platform_chrome
@@ -71,6 +72,7 @@ services:
 volumes:
   db-platform:
   node-modules:
+  vendor-bundle:
   webpack-cache:
 
 # Note all Braven web app docker dev envs use this same network so they can talk to each other.

--- a/docker-compose/scripts/docker_compose_run.sh
+++ b/docker-compose/scripts/docker_compose_run.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -e
 
+# Turn off automatic visual mode using the mouse
+echo "set mouse-=a" >> ~/.vimrc
+
 echo "Checking if the SALESFORCE ENV vars are setup"
 if [ -z "$SALESFORCE_HOST" ] || \
    [ -z "$SALESFORCE_PLATFORM_CONSUMER_KEY" ] || \


### PR DESCRIPTION
In my case, I need to debug some issues in this gem
https://github.com/bebraven/rubycas-server-core so with this change I can
now just go into the container, navigate to the code in `vendor/bundle`
add logs or `binding.pry` statements, restart the container and the changes
will be run.

Note the comment in the README about needing to blow away the vendor-bundle
volume if you muck it up too much and want to get back to a pristine state.