### PR TITLE
Make SSO logout work properly

### DIFF
--- a/app/views/home/welcome.html.erb
+++ b/app/views/home/welcome.html.erb
@@ -17,4 +17,7 @@
 <div>
 <%= link_to 'Portal', canvas_url, target: :_blank %>
 </div>
-
+<br/>
+<div>
+<%= link_to 'Log Out', destroy_user_session_path,  method: :delete %>
+</div>

--- a/config/rubycas.yml
+++ b/config/rubycas.yml
@@ -1,4 +1,5 @@
-production: &default
+default: &default
+  enable_single_sign_out: true
   maximum_unused_login_ticket_lifetime: 300
   maximum_unused_service_ticket_lifetime: 300
   maximum_session_lifetime: 172800
@@ -32,7 +33,7 @@ production: &default
     source: cas_authenticator.rb
 <% end %>
 
-development:
+development: &development_config
   <<: *default
   log:
     output: 
@@ -58,34 +59,19 @@ development:
 <% end %>
 
 test:
-  <<: *default
+  <<: *development_config
   log:
     output: 
     level: ERROR
-  public_site_domain: joinweb
-  # this should be the *top* domain - so even for staging, it should be .join.bebraven.org stilldefault_service: http://canvasweb/login/cas
-  cookie_domain: .localhost 
   organization: "RSPEC-TEST"
   infoline: "This is an rspec test."  
-  theme: simple
   database:
     <<: *default_db
     database: platform_test
-<% if ENV['BZ_AUTH_SERVER'] %>
-  authenticator:
-    <<: *default_bz_auth
-    server: joinweb
-    ssl: false
-    port: 3001
-    allow_self_signed: true
-<% else %>
-  authenticator:
-    <<: *default_cas_auth
-<% end %>
   uri_path: /test
   disable_auto_migrations: true
   quiet: true
   default_locale: en
-  enable_single_sign_out: true
 
-  
+production: &default
+  <<: *default

--- a/config/rubycas.yml
+++ b/config/rubycas.yml
@@ -73,5 +73,5 @@ test:
   quiet: true
   default_locale: en
 
-production: &default
+production:
   <<: *default

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -19,7 +19,7 @@ require 'platform_helper'
 
 Dir["./spec/support/**/*.rb"].sort.each{|f| require f}
 
-ENV['RAILS_ENV'] ||= 'test'
+ENV['RAILS_ENV'] = 'test'
 require File.expand_path('../../config/environment', __FILE__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?


### PR DESCRIPTION
Enable single-signout setting in SSO server.

With enable_single_sign_out set to true, it calls into each app that has authenticated
with this ticket and tells them to logout.

The `enable_single_sign_out` setting was only enabled in the test
configuration. It should be enabled for all environments. I think this was an
oversight. Refactor the whole rubycas.yml settings file so that shared settings
are defined in one place and each env only changes settings specific to it. 

### Test Plan:

platform logout
1. Login to platform.
2. Login to portal in a separate tab.
3. Logout of platform.
4. Try to hit a new page in portal, it should redirect to the sign-in page.

portal logout
1. Repeat step 1 & 2 above.
2. Logout of Portal
3. Try to hit a new page in platform, redirects to sign-in page.