### PR TITLE
Fix radio questions

### DIFF
--- a/app/javascript/ckeditor/insertradioquestioncommand.js
+++ b/app/javascript/ckeditor/insertradioquestioncommand.js
@@ -19,6 +19,8 @@ export default class InsertRadioQuestionCommand extends Command {
 
 function createRadioQuestion( writer ) {
     const radioGroup = uid();
+    // Value must be unique within each group, but otherwise doesn't matter.
+    // No reason to tie in retained data or anything, we can just use "1".
     const radioFirstValue = '1';
     const radioFirstID = [radioGroup, radioFirstValue].join('_');
 

--- a/app/javascript/ckeditor/insertradioquestioncommand.js
+++ b/app/javascript/ckeditor/insertradioquestioncommand.js
@@ -18,7 +18,11 @@ export default class InsertRadioQuestionCommand extends Command {
 }
 
 function createRadioQuestion( writer ) {
-    const radioQuestion = writer.createElement( 'moduleBlock', {'data-radio-group': uid()} );
+    const radioGroup = uid();
+    const radioFirstValue = '1';
+    const radioFirstID = [radioGroup, radioFirstValue].join('_');
+
+    const radioQuestion = writer.createElement( 'moduleBlock', {'data-radio-group': radioGroup} );
     const question = writer.createElement( 'question', { 'data-grade-as': 'radio' } );
     const questionTitle = writer.createElement( 'questionTitle' );
     const questionBody = writer.createElement( 'questionBody' );
@@ -26,8 +30,12 @@ function createRadioQuestion( writer ) {
     const questionFieldset = writer.createElement( 'questionFieldset' );
     const doneButton = writer.createElement( 'doneButton' );
     const radioDiv = writer.createElement( 'radioDiv' );
-    const radioInput = writer.createElement( 'radioInput' );
-    const radioLabel = writer.createElement( 'radioLabel' );
+    const radioInput = writer.createElement( 'radioInput', {
+        name: radioGroup,
+        id: radioFirstID,
+        value: radioFirstValue,
+    } );
+    const radioLabel = writer.createElement( 'radioLabel', { 'for': radioFirstID } );
     const radioInlineFeedback = writer.createElement( 'radioInlineFeedback' );
     const answer = writer.createElement( 'answer' );
     const answerTitle = writer.createElement( 'answerTitle' );

--- a/app/javascript/ckeditor/moduleblockediting.js
+++ b/app/javascript/ckeditor/moduleblockediting.js
@@ -61,6 +61,7 @@ export default class ModuleBlockEditing extends Plugin {
                 // FIXME: Camelcase is broken with CKE built-in conversions, esp. on upcast
                 'blockClasses',
                 'data-icon',
+                'data-radio-group',
             ],
         } );
     }
@@ -94,26 +95,55 @@ export default class ModuleBlockEditing extends Plugin {
                 // Remove icon from class
                 const blockClasses = srcClasses.replace(icon, "").trim();
 
-                return modelWriter.createElement( 'moduleBlock', {
+                let attributes = {
                     'blockClasses': blockClasses,
                     'data-icon': icon,
-                });
+                }
+
+                // Special radio-question support.
+                // This attribute is set in insertradioquestioncommand.js.
+                const radioGroup = viewElement.getAttribute( 'data-radio-group' );
+                if ( radioGroup ) {
+                    attributes['data-radio-group'] = radioGroup;
+                }
+
+                return modelWriter.createElement( 'moduleBlock', attributes );
             }
         } );
         conversion.for( 'dataDowncast' ).elementToElement( {
             model: 'moduleBlock',
             view: ( modelElement, viewWriter ) => {
-                return viewWriter.createContainerElement( 'div', {
+                let attributes = {
                     'class': modelElement.getAttribute('blockClasses') || 'module-block',
-                } );
+                    'data-icon': modelElement.getAttribute('data-icon') || 'module-block-question',
+                }
+
+                // Special radio-question support.
+                // This attribute is set in insertradioquestioncommand.js.
+                const radioGroup = modelElement.getAttribute( 'data-radio-group' );
+                if ( radioGroup ) {
+                    attributes['data-radio-group'] = radioGroup;
+                }
+
+                return viewWriter.createContainerElement( 'div', attributes );
             }
         } );
         conversion.for( 'editingDowncast' ).elementToElement( {
             model: 'moduleBlock',
             view: ( modelElement, viewWriter ) => {
-                const moduleBlock = viewWriter.createContainerElement( 'div', {
+                let attributes = {
                     'class': modelElement.getAttribute('blockClasses') || 'module-block',
-                } );
+                    'data-icon': modelElement.getAttribute('data-icon') || 'module-block-question',
+                }
+
+                // Special radio-question support.
+                // This attribute is set in insertradioquestioncommand.js.
+                const radioGroup = modelElement.getAttribute( 'data-radio-group' );
+                if ( radioGroup ) {
+                    attributes['data-radio-group'] = radioGroup;
+                }
+
+                const moduleBlock = viewWriter.createContainerElement( 'div', attributes );
 
                 return toWidget( moduleBlock, viewWriter, { label: 'module-block widget', hasSelectionHandle: true } );
             }

--- a/app/javascript/ckeditor/radioquestionediting.js
+++ b/app/javascript/ckeditor/radioquestionediting.js
@@ -59,12 +59,6 @@ export default class RadioQuestionEditing extends Plugin {
     _defineSchema() {
         const schema = this.editor.model.schema;
 
-        schema.register( 'radioQuestion', {
-            isObject: true,
-            allowIn: 'section',
-            allowAttributes: [ 'data-radio-group' ]
-        } );
-
         schema.register( 'radioDiv', {
             isObject: true,
             allowIn: [ 'questionFieldset' ]
@@ -90,52 +84,12 @@ export default class RadioQuestionEditing extends Plugin {
             allowIn: 'radioDiv',
             allowContentOf: '$block'
         } );
-
-        schema.addChildCheck( ( context, childDefinition ) => {
-            // Disallow adding questions inside answerText boxes.
-            if ( context.endsWith( 'answerText' ) && childDefinition.name == 'radioQuestion' ) {
-                return false;
-            }
-        } );
     }
 
     _defineConverters() {
         const editor = this.editor;
         const conversion = editor.conversion;
         const { editing, data, model } = editor;
-
-        // <radioQuestion> converters
-        conversion.for( 'upcast' ).elementToElement( {
-            view: {
-                name: 'div',
-                classes: ['module-block', 'module-block-radio']
-            },
-            model: ( viewElement, modelWriter ) => {
-                return modelWriter.createElement( 'radioQuestion', {
-                    'data-radio-group': viewElement.getAttribute( 'data-radio-group' )
-                } );
-            }
-        } );
-        conversion.for( 'dataDowncast' ).elementToElement( {
-            model: 'radioQuestion',
-            view: ( modelElement, viewWriter ) => {
-                return viewWriter.createEditableElement( 'div', {
-                    'class': 'module-block module-block-radio',
-                    'data-radio-group': modelElement.getAttribute( 'data-radio-group' )
-                } );
-            }
-        } );
-        conversion.for( 'editingDowncast' ).elementToElement( {
-            model: 'radioQuestion',
-            view: ( modelElement, viewWriter ) => {
-                const radioQuestion = viewWriter.createContainerElement( 'div', {
-                    'class': 'module-block module-block-radio',
-                    'data-radio-group': modelElement.getAttribute( 'data-radio-group' )
-                } );
-
-                return toWidget( radioQuestion, viewWriter, { label: 'radio-question widget' } );
-            }
-        } );
 
         // <radioDiv> converters
         conversion.for( 'upcast' ).elementToElement( {

--- a/app/javascript/ckeditor/radioquestionediting.js
+++ b/app/javascript/ckeditor/radioquestionediting.js
@@ -195,10 +195,10 @@ export default class RadioQuestionEditing extends Plugin {
 
                 return modelWriter.createElement( 'radioInput', new Map( [
                     ...filterAllowedAttributes(viewElement.getAttributes()),
-                    [ 'id', id ],
+                    [ 'id', [ radioGroupName, id ].join( '_' ) ],
                     [ 'name', radioGroupName ],
-                    [ 'value', viewElement.getAttribute('value') ],
-                    [ 'data-bz-retained', id ],
+                    [ 'value', viewElement.getAttribute('value') || id ],
+                    [ 'data-bz-retained', radioGroupName ],
                     [ 'data-correctness', viewElement.getAttribute('data-correctness') || '' ]
                 ] ) );
             }
@@ -230,10 +230,10 @@ export default class RadioQuestionEditing extends Plugin {
                 return viewWriter.createEmptyElement( 'input', new Map( [
                     ...filterAllowedAttributes(modelElement.getAttributes()),
                     [ 'type', 'radio' ],
-                    [ 'id', id ],
+                    [ 'id', [ radioGroupName, id ].join( '_' ) ],
                     [ 'name', radioGroupName ],
-                    [ 'value', modelElement.getAttribute('value') ],
-                    [ 'data-bz-retained', id ],
+                    [ 'value', modelElement.getAttribute('value') || id ],
+                    [ 'data-bz-retained', radioGroupName ],
                     [ 'data-correctness', modelElement.getAttribute('data-correctness') || '' ]
                 ] ) );
             }
@@ -264,10 +264,10 @@ export default class RadioQuestionEditing extends Plugin {
                 return viewWriter.createEmptyElement( 'input', new Map( [
                     ...filterAllowedAttributes(modelElement.getAttributes()),
                     [ 'type', 'radio' ],
-                    [ 'id', id ],
+                    [ 'id', [ radioGroupName, id ].join( '_' ) ],
                     [ 'name', radioGroupName ],
-                    [ 'value', modelElement.getAttribute('value') ],
-                    [ 'data-bz-retained', id ],
+                    [ 'value', modelElement.getAttribute('value') || id ],
+                    [ 'data-bz-retained', radioGroupName ],
                     [ 'data-correctness', modelElement.getAttribute('data-correctness') || '' ]
                 ] ) );
                 return toWidget( input, viewWriter );

--- a/app/javascript/ckeditor/radioquestionediting.js
+++ b/app/javascript/ckeditor/radioquestionediting.js
@@ -127,8 +127,6 @@ export default class RadioQuestionEditing extends Plugin {
                 }
             },
             model: ( viewElement, modelWriter ) => {
-                const id = viewElement.getAttribute('data-bz-retained') || this._nextRetainedDataId();
-
                 // All radio buttons in the same question must share the same 'name' attribute,
                 // so let's get a reference to the ancestor module block and use its group name
                 // attribute, if available.
@@ -140,29 +138,36 @@ export default class RadioQuestionEditing extends Plugin {
                 }
                 catch (e) {
                     if (e instanceof TypeError) {
-                        // We're not in a radio question; use something else for the group name.
+                        // We're not in a radio question (e.g. we're a radio button inside a table
+                        // as part of a matrix question). Use something else for the group name.
                         radioGroupName = viewElement.getAttribute('name');
                     } else {
                         throw e;
                     }
                 }
 
+                // Get the retained data ID, with radioGroupName as a fallback.
+                const retainedID = viewElement.getAttribute('data-bz-retained') || radioGroupName;
+
+                // Radio values don't have to be unique within the page, only within the group.
+                // But we already have the RetainedData plugin, so let's just use that as
+                // our fallback.
+                const radioValue = viewElement.getAttribute('value') || this._nextRetainedDataId();
+
                 return modelWriter.createElement( 'radioInput', new Map( [
                     ...filterAllowedAttributes(viewElement.getAttributes()),
-                    [ 'id', [ radioGroupName, id ].join( '_' ) ],
+                    [ 'id', [ radioGroupName, radioValue ].join( '_' ) ],
                     [ 'name', radioGroupName ],
-                    [ 'value', viewElement.getAttribute('value') || id ],
-                    [ 'data-bz-retained', radioGroupName ],
+                    [ 'value', radioValue ],
+                    [ 'data-bz-retained', retainedID ],
                     [ 'data-correctness', viewElement.getAttribute('data-correctness') || '' ]
                 ] ) );
             }
 
         } );
-        conversion.for( 'dataDowncast' ).elementToElement( {
+        conversion.for( 'downcast' ).elementToElement( {
             model: 'radioInput',
             view: ( modelElement, viewWriter ) => {
-                const id = modelElement.getAttribute('data-bz-retained') || this._nextRetainedDataId();
-
                 // All radio buttons in the same question must share the same 'name' attribute,
                 // so let's get a reference to the ancestor module block and use its group name
                 // attribute, if available.
@@ -174,57 +179,31 @@ export default class RadioQuestionEditing extends Plugin {
                 }
                 catch (e) {
                     if (e instanceof TypeError) {
-                        // We're not in a radio question; use something else for the group name.
+                        // We're not in a radio question (e.g. we're a radio button inside a table
+                        // as part of a matrix question). Use something else for the group name.
                         radioGroupName = modelElement.getAttribute('name');
                     } else {
                         throw e;
                     }
                 }
 
-                return viewWriter.createEmptyElement( 'input', new Map( [
-                    ...filterAllowedAttributes(modelElement.getAttributes()),
-                    [ 'type', 'radio' ],
-                    [ 'id', [ radioGroupName, id ].join( '_' ) ],
-                    [ 'name', radioGroupName ],
-                    [ 'value', modelElement.getAttribute('value') || id ],
-                    [ 'data-bz-retained', radioGroupName ],
-                    [ 'data-correctness', modelElement.getAttribute('data-correctness') || '' ]
-                ] ) );
-            }
-        } );
-        conversion.for( 'editingDowncast' ).elementToElement( {
-            model: 'radioInput',
-            view: ( modelElement, viewWriter ) => {
-                const id = modelElement.getAttribute('data-bz-retained') || this._nextRetainedDataId();
+                // Get the retained data ID, with radioGroupName as a fallback.
+                const retainedID = modelElement.getAttribute('data-bz-retained') || radioGroupName;
 
-                // All radio buttons in the same question must share the same 'name' attribute,
-                // so let's get a reference to the ancestor module block and use its group name
-                // attribute, if available.
-                let radioGroupName;
-                try {
-                    const moduleBlockRadioDiv = modelElement.parent.parent.parent.parent.parent;
-                    // Try to use the existing name first; fall back to question group attribute.
-                    radioGroupName = modelElement.getAttribute('name') || moduleBlockRadioDiv.getAttribute('data-radio-group');
-                }
-                catch (e) {
-                    if (e instanceof TypeError) {
-                        // We're not in a radio question; use something else for the group name.
-                        radioGroupName = modelElement.getAttribute('name');
-                    } else {
-                        throw e;
-                    }
-                }
+                // Radio values don't have to be unique within the page, only within the group.
+                // But we already have the RetainedData plugin, so let's just use that as
+                // our fallback.
+                const radioValue = modelElement.getAttribute('value') || this._nextRetainedDataId();
 
                 return viewWriter.createEmptyElement( 'input', new Map( [
                     ...filterAllowedAttributes(modelElement.getAttributes()),
                     [ 'type', 'radio' ],
-                    [ 'id', [ radioGroupName, id ].join( '_' ) ],
+                    [ 'id', [ radioGroupName, radioValue ].join( '_' ) ],
                     [ 'name', radioGroupName ],
-                    [ 'value', modelElement.getAttribute('value') || id ],
-                    [ 'data-bz-retained', radioGroupName ],
+                    [ 'value', radioValue ],
+                    [ 'data-bz-retained', retainedID ],
                     [ 'data-correctness', modelElement.getAttribute('data-correctness') || '' ]
                 ] ) );
-                return toWidget( input, viewWriter );
             }
         } );
 

--- a/app/javascript/ckeditor/radioquestionediting.js
+++ b/app/javascript/ckeditor/radioquestionediting.js
@@ -120,7 +120,7 @@ export default class RadioQuestionEditing extends Plugin {
             model: 'radioQuestion',
             view: ( modelElement, viewWriter ) => {
                 return viewWriter.createEditableElement( 'div', {
-                    class: 'module-block module-block-radio',
+                    'class': 'module-block module-block-radio',
                     'data-radio-group': modelElement.getAttribute( 'data-radio-group' )
                 } );
             }
@@ -129,7 +129,7 @@ export default class RadioQuestionEditing extends Plugin {
             model: 'radioQuestion',
             view: ( modelElement, viewWriter ) => {
                 const radioQuestion = viewWriter.createContainerElement( 'div', {
-                    class: 'module-block module-block-radio',
+                    'class': 'module-block module-block-radio',
                     'data-radio-group': modelElement.getAttribute( 'data-radio-group' )
                 } );
 


### PR DESCRIPTION
Task: https://app.asana.com/0/1170776727341290/1172643959550099/f

Basically, I have no idea how radio buttons work, so I implemented this totally backwards. This PR fixes that.

I'd appreciate if someone can double-check my logic, bc this is confusing.

Things to know:

* Radio group **MUST** be unique for each question. Every button in the question shares the group.
* Group is tracked for convenience in `module-block[data-radio-group]`, but is actually determined by the radio `input`'s `name` attribute.
* Each radio has an `id` attribute that **MUST** be unique in the document.
* Each radio has a `data-bz-retained` ID that **MAY** match the `name` attribute, and **MUST** be the same for all radio `input`s in a group.
* Each radio has a `value` attribute that **MUST** be unique within each group (uniqueness within the document does not matter).
* Each radio has a `data-correctness` attribute that is used to show color / tally results for autograding.
* Each radio has a corresponding `label`, with a `for` attrubute that matches the `input`'s `id` attribute.

Issues I noticed while doing this PR, but consider out of scope for Booster:

* When you add a radio / checklist option in the editor, the attributes are not set. The attributes are only set once you reload the editor (e.g. toggle code->design, or save the document and let it reload.) This means there's an edge-case bug where if you add a radio button or checklist option, save, then publish, that radio button will not work. There are two workarounds: 1) after adding an option, save, save again, publish or 2) after adding an option, toggle code tab, toggle design tab, save, publish. Task: https://app.asana.com/0/1170776727341290/1175871850555492/f
* A similar issue when you insert a checklist question - the first option will be non-functional until you follow the steps above.