### PR TITLE
Auto login the user when they confirm their new account.

### DIFF
--- a/app/controllers/cas_controller.rb
+++ b/app/controllers/cas_controller.rb
@@ -256,7 +256,9 @@ class CasController < ApplicationController
 
     @lt = LT.create! @request_client
 
-    if @gateway && @service
+    if current_user
+      sign_out_and_redirect(current_user) and return
+    elsif @gateway && @service
       return render :login
     elsif @continue_url
       return render :logout

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Users::ConfirmationsController < Devise::ConfirmationsController
+  include RubyCAS::Server::Core::Tickets
+
   layout 'accounts'
   before_action :configure_permitted_parameters
 
@@ -18,9 +20,14 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
   end
 
   # GET /resource/confirmation?confirmation_token=abcdef
-  # def show
-  #   super
-  # end
+  def show
+    super do
+      Rails.logger.debug("Account creation confirmed for #{resource}. Signing them in using CAS SSO.")
+      redirect_path_for_user = sign_in_and_get_redirect_path
+      set_flash_message!(:notice, :confirmed)
+      redirect_to redirect_path_for_user and return
+    end
+  end
 
   protected
 
@@ -29,14 +36,35 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
     new_user_confirmation_path 
   end
 
-  # The path used after confirmation.
-  def after_confirmation_path_for(_, _)
-    # After confirming their account, have them login through CAS instead of being immediately signed in.
-    # Note: if you wanted to sign them in, call this:
-    # sign_in(resource)
-    cas_login_url
-  end
+#  # The path used after confirmation.
+#  def after_confirmation_path_for(resource_name, resource)
+#    cas_login_url
+#  end
 
+  def cas_login_url
+    ::Devise.cas_client.add_service_to_login_url(::Devise.cas_service_url(request.url, devise_mapping))
+  end
+  helper_method :cas_login_url
+
+  # Does a CAS SSO login for the app they are redirected to on login. E.g. if they have Canvas access,
+  # auto-log them in there, otherwise do it here in the platform.
+  def sign_in_and_get_redirect_path
+     username = resource.email
+     if resource.canvas_id
+       login_service_url = URI.join(CanvasAPI.client.canvas_url, "/login/cas").to_s
+     else
+       login_service_url = ::Devise.cas_service_url(request.url, devise_mapping) 
+     end
+
+     # TGT = Ticket Granting Ticket helper, ST = Service Ticket helper. See: lib/rubycas-server-core/tickets.rb 
+     tgt = TGT.create! username, ::Devise.cas_client
+     response.set_cookie('tgt', tgt.to_s) # When the app calls back to validate the ticket, this is what makes that work.
+     st = ST.create! login_service_url, username, tgt, ::Devise.cas_client
+
+     Rails.logger.debug("Done signing in confirmed user #{username} with CAS Ticket granting cookie '#{tgt.inspect}' and Service Ticket #{st.inspect}")
+
+     Utils.build_ticketed_url(login_service_url, st)
+  end
 
   private
 
@@ -44,8 +72,4 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
     devise_parameter_sanitizer.permit(:create, keys: [:salesforce_id])
   end
 
-  def cas_login_url
-    ::Devise.cas_client.add_service_to_login_url(::Devise.cas_service_url(request.url, devise_mapping))
-  end
-  helper_method :cas_login_url
 end


### PR DESCRIPTION
### Test Plan:
- Register a new user who has Portal access and when you click the email
  confirmation link it logs you into the Portal.
- Note: we currently don't have a way to register an admin user without
  Portal access, so we can't test that. When the day comes it'll break
  if I got it wrong