### PR TITLE
Remove broken map reference

### DIFF
--- a/app/assets/stylesheets/reboot.css
+++ b/app/assets/stylesheets/reboot.css
@@ -329,5 +329,3 @@ template {
 [hidden] {
   display: none !important;
 }
-/*# sourceMappingURL=bootstrap-reboot.css.map */
-


### PR DESCRIPTION
No task. Fixes this annoying error on every page load:

```
platformweb_1      | ActionController::RoutingError (No route matches [GET] "/assets/bootstrap-reboot.css.map"):
platformweb_1      |
platformweb_1      | actionpack (6.0.2.2) lib/action_dispatch/middleware/debug_exceptions.rb:36:in `call'
platformweb_1      | web-console (4.0.1) lib/web_console/middleware.rb:132:in `call_app'
platformweb_1      | web-console (4.0.1) lib/web_console/middleware.rb:28:in `block in call'
platformweb_1      | web-console (4.0.1) lib/web_console/middleware.rb:17:in `catch'
platformweb_1      | web-console (4.0.1) lib/web_console/middleware.rb:17:in `call'
platformweb_1      | actionpack (6.0.2.2) lib/action_dispatch/middleware/show_exceptions.rb:33:in `call'
platformweb_1      | railties (6.0.2.2) lib/rails/rack/logger.rb:38:in `call_app'
platformweb_1      | railties (6.0.2.2) lib/rails/rack/logger.rb:26:in `block in call'
platformweb_1      | activesupport (6.0.2.2) lib/active_support/tagged_logging.rb:80:in `block in tagged'
platformweb_1      | activesupport (6.0.2.2) lib/active_support/tagged_logging.rb:28:in `tagged'
platformweb_1      | activesupport (6.0.2.2) lib/active_support/tagged_logging.rb:80:in `tagged'
platformweb_1      | railties (6.0.2.2) lib/rails/rack/logger.rb:26:in `call'
platformweb_1      | sprockets-rails (3.2.1) lib/sprockets/rails/quiet_assets.rb:11:in `block in call'
platformweb_1      | activesupport (6.0.2.2) lib/active_support/logger_silence.rb:36:in `silence'
platformweb_1      | activesupport (6.0.2.2) lib/active_support/logger.rb:64:in `block (3 levels) in broadcast'
platformweb_1      | activesupport (6.0.2.2) lib/active_support/logger_silence.rb:36:in `silence'
platformweb_1      | activesupport (6.0.2.2) lib/active_support/logger.rb:62:in `block (2 levels) in broadcast'
platformweb_1      | sprockets-rails (3.2.1) lib/sprockets/rails/quiet_assets.rb:11:in `call'
platformweb_1      | actionpack (6.0.2.2) lib/action_dispatch/middleware/remote_ip.rb:81:in `call'
platformweb_1      | actionpack (6.0.2.2) lib/action_dispatch/middleware/request_id.rb:27:in `call'
platformweb_1      | rack (2.2.2) lib/rack/method_override.rb:24:in `call'
platformweb_1      | rack (2.2.2) lib/rack/runtime.rb:22:in `call'
platformweb_1      | activesupport (6.0.2.2) lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
platformweb_1      | actionpack (6.0.2.2) lib/action_dispatch/middleware/executor.rb:14:in `call'
platformweb_1      | rack-livereload (0.3.17) lib/rack/livereload.rb:23:in `_call'
platformweb_1      | rack-livereload (0.3.17) lib/rack/livereload.rb:14:in `call'
platformweb_1      | actionpack (6.0.2.2) lib/action_dispatch/middleware/static.rb:126:in `call'
platformweb_1      | rack (2.2.2) lib/rack/sendfile.rb:110:in `call'
platformweb_1      | actionpack (6.0.2.2) lib/action_dispatch/middleware/host_authorization.rb:83:in `call'
platformweb_1      | sentry-raven (3.0.0) lib/raven/integrations/rack.rb:51:in `call'
platformweb_1      | webpacker (4.2.2) lib/webpacker/dev_server_proxy.rb:23:in `perform_request'
platformweb_1      | rack-proxy (0.6.5) lib/rack/proxy.rb:57:in `call'
platformweb_1      | railties (6.0.2.2) lib/rails/engine.rb:526:in `call'
platformweb_1      | puma (3.12.4) lib/puma/configuration.rb:227:in `call'
platformweb_1      | puma (3.12.4) lib/puma/server.rb:675:in `handle_request'
platformweb_1      | puma (3.12.4) lib/puma/server.rb:476:in `process_client'
platformweb_1      | puma (3.12.4) lib/puma/server.rb:334:in `block in run'
platformweb_1      | puma (3.12.4) lib/puma/thread_pool.rb:135:in `block in spawn_thread'
```