### PR TITLE
On forgot password reset success, display a message.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -51,4 +51,11 @@ class ApplicationController < ActionController::Base
   end
   helper_method :canvas_url
 
+  # This is just the main login path that redirects to the proper place on success.
+  # e.g. https://platform.bebraven.org/cas/login?service=https%3A%2F%2Fportal.bebraven.org%2Flogin%2Fcas
+  def cas_login_url
+    ::Devise.cas_client.add_service_to_login_url(::Devise.cas_service_url(request.url, devise_mapping))
+  end
+  helper_method :cas_login_url
+
 end

--- a/app/controllers/cas_controller.rb
+++ b/app/controllers/cas_controller.rb
@@ -33,6 +33,8 @@ class CasController < ApplicationController
 
     # optional params
     @gateway = params['gateway'] == 'true' || params['gateway'] == '1'
+    @message = { :type => 'notice', :message => params[:notice] } if params[:notice]
+ 
 
     if tgc = request.cookies['tgt']
       tgt, tgt_error = TGT.validate(tgc)

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -14,11 +14,9 @@ class Users::PasswordsController < Devise::PasswordsController
   # end
 
   # GET /resource/password/edit?reset_password_token=abcdef
-  def edit
-    super do
-      sign_in(resource)
-    end
-  end
+  # def edit
+  #  super
+  # end
 
   # PUT /resource/password
   # def update
@@ -27,12 +25,16 @@ class Users::PasswordsController < Devise::PasswordsController
 
   # protected
 
-  # def after_resetting_password_path_for(resource)
-  #   super(resource)
-  # end
+  def after_resetting_password_path_for(resource)
+     login_url = cas_login_url
+     login_url += (URI.parse(cas_login_url).query ? '&' : '?')
+     login_url += "notice=Password reset successfully.".freeze
+     login_url
+  end
 
   # The path used after sending reset password instructions
   def after_sending_reset_password_instructions_path_for(_)
     users_password_check_email_path
   end
+
 end


### PR DESCRIPTION
I'd rather have them login directly after changing their password vs
auto logging them in so they can update their password management
software or do whatever they normally do to keep track of passwords.

Note: I tried to use some better approaches to do this but it was taking
way too much time. So I'm just piggybacking off the existing message
notices for the cas login form and sticking with a GET request. Also
fancier query param parsing / manipulation stuff wasn't worth it.

Test Plan
- Click forgot password, enter your email, click the link in the email
  and you should see a message saying it was successful on the sign-in form
  you're redirected to.