### PR TITLE
Store newly created Canvas user's canvas_id in Salesforce.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -102,6 +102,7 @@ class User < ApplicationRecord
   def do_account_registration
     if sync_salesforce_info # They can't register for Canvas access if they aren't Enrolled in Salesforce
       setup_canvas_access
+      store_canvas_id_in_salesforce
     end
   end
 
@@ -128,4 +129,7 @@ class User < ApplicationRecord
     end
   end
 
+  def store_canvas_id_in_salesforce
+    SalesforceAPI.client.set_canvas_id(salesforce_id, canvas_id)
+  end
 end

--- a/lib/salesforce_api.rb
+++ b/lib/salesforce_api.rb
@@ -65,6 +65,12 @@ class SalesforceAPI
     handle_rest_client_error(e)
   end
 
+  def patch(path, body, headers={})
+    RestClient.patch("#{@salesforce_url}#{path}", body, @global_headers.merge(headers))
+  rescue => e
+    handle_rest_client_error(e)
+  end
+
   def get_program_info(program_id)
     soql_query = 
       "SELECT Id, Name, Target_Course_ID_in_LMS__c, LMS_Coach_Course_Id__c, School__c, " \
@@ -110,6 +116,11 @@ class SalesforceAPI
       "IsEmailBounced,BZ_Geographical_Region__c,Current_Employer__c,Career__c,Title,Job_Function__c,Current_Major__c," \
       "High_School_Graduation_Date__c,Anticipated_Graduation__c,Graduate_Year__c")
     JSON.parse(response.body)
+  end
+
+  def set_canvas_id(contact_id, canvas_id)
+    body = { 'Canvas_User_ID__c' => canvas_id }
+    response = patch("/services/data/v48.0/sobjects/Contact/#{contact_id}", body.to_json, JSON_HEADERS)
   end
 
 # TODO: delete me if we don't need to use a POST for any reason. I figured out how to accept query params in the get after I had implement this.

--- a/spec/lib/salesforce_api_spec.rb
+++ b/spec/lib/salesforce_api_spec.rb
@@ -106,4 +106,18 @@ RSpec.describe SalesforceAPI do
     end
   end
 
+  describe '#set_canvas_id(contact_id, canvas_id)' do
+    let(:salesforce) { SalesforceAPI.client }
+    let(:contact_id) { '003170000125IpSAAU' }
+
+    it 'calls the correct endpoint' do
+      contact_json = FactoryBot.json(:salesforce_contact)
+      request_url_regex = /#{SALESFORCE_INSTANCE_URL}\/services\/data\/v48.0\/sobjects\/Contact\/#{contact_json['id']}.*/
+      stub_request(:patch, request_url_regex)
+
+      response = salesforce.set_canvas_id(contact_json['id'], '1234')
+
+      expect(WebMock).to have_requested(:patch, request_url_regex).once
+    end
+  end
 end


### PR DESCRIPTION
Test plan:
- Sign-up a new Enrolled Participant from Salesforce. See that their
  Canvas User ID field gets set on the Contact record