### PR TITLE
Add anchor link to <{question, answer, content}Title>

### DIFF
--- a/app/javascript/ckeditor/contentcommonediting.js
+++ b/app/javascript/ckeditor/contentcommonediting.js
@@ -306,14 +306,14 @@ export default class ContentCommonEditing extends Plugin {
 
         // <toc-link-href> converters
         // Using the low-level dispatcher because what we want is elementToNothing, which isn't a CKE funciton.
-        editor.conversion.for( 'upcast' ).add( dispatcher => { dispatcher.on( 'element:a', ( evt, data, conversionApi ) => {
-            if ( conversionApi.consumable.consume( data.viewItem, { name: true, attributes: [ 'href', 'toc' ] } ) ) {
-                // <a> element is inline and is NOT represented in the model.
-                // This is why we need to convert only children.
-                const a = conversionApi.convertChildren( data.viewItem, data.modelCursor );
-                console.log(data.viewItem, a);
-            }
-        }, { priority: 'high' } ) } );
+        // editor.conversion.for( 'upcast' ).add( dispatcher => { dispatcher.on( 'element:a', ( evt, data, conversionApi ) => {
+        //     if ( conversionApi.consumable.consume( data.viewItem, { name: true, attributes: [ 'href', 'toc' ] } ) ) {
+        //         // <a> element is inline and is NOT represented in the model.
+        //         // This is why we need to convert only children.
+        //         const a = conversionApi.convertChildren( data.viewItem, data.modelCursor );
+        //         console.log(data.viewItem, a);
+        //     }
+        // }, { priority: 'high' } ) } );
         /* this one just never adds the element to the view and we dont know why
         conversion.for( 'dataDowncast' ).attributeToElement( {
             model: {
@@ -330,27 +330,27 @@ export default class ContentCommonEditing extends Plugin {
         } );
         */
         // This one adds the a inside the h5, but puts the text before the a instead of inside it
-        conversion.for( 'dataDowncast' ).add( dispatcher => {
-            dispatcher.on( 'attribute:toc-link-href', ( evt, data, conversionApi ) => {
-              const href = data.attributeNewValue;
-              // The heading will be already converted - so it will be present in the view.
-              const viewHeading = conversionApi.mapper.toViewElement( data.item );
+        // conversion.for( 'dataDowncast' ).add( dispatcher => {
+        //     dispatcher.on( 'attribute:toc-link-href', ( evt, data, conversionApi ) => {
+        //       const href = data.attributeNewValue;
+        //       // The heading will be already converted - so it will be present in the view.
+        //       const viewHeading = conversionApi.mapper.toViewElement( data.item );
 
-              // Below will wrap newly created link element by already converted heading.
+        //       // Below will wrap newly created link element by already converted heading.
 
-              // 1. Create empty link element.
-              const linkElement = conversionApi.writer.createContainerElement( 'a', { href, toc: true } );
+        //       // 1. Create empty link element.
+        //       const linkElement = conversionApi.writer.createContainerElement( 'a', { href, toc: true } );
 
-              // 2. Insert link after associated heading.
-              const positionAfterHeading = conversionApi.writer.createPositionAfter( viewHeading );
-              conversionApi.writer.insert( positionAfterHeading, linkElement );
+        //       // 2. Insert link after associated heading.
+        //       const positionAfterHeading = conversionApi.writer.createPositionAfter( viewHeading );
+        //       conversionApi.writer.insert( positionAfterHeading, linkElement );
 
-              // 3. Move whole link to a converted heading.
-              const rangeOnLink = conversionApi.writer.createRangeOn( linkElement );
-              const positionAtHeading = conversionApi.writer.createPositionAt( viewHeading, 0 );
-              conversionApi.writer.move( rangeOnLink, positionAtHeading );
-            }, { priority: 'normal' } );
-        } );
+        //       // 3. Move whole link to a converted heading.
+        //       const rangeOnLink = conversionApi.writer.createRangeOn( linkElement );
+        //       const positionAtHeading = conversionApi.writer.createPositionAt( viewHeading, 0 );
+        //       conversionApi.writer.move( rangeOnLink, positionAtHeading );
+        //     }, { priority: 'normal' } );
+        // } );
         /* don't care about this for now
         conversion.for ('editingDowncast' ).attributeToElement( {
             model: 'toc-link-href',
@@ -365,6 +365,23 @@ export default class ContentCommonEditing extends Plugin {
             },
         });
         */
+
+        conversion.for( 'upcast' ).add( dispatcher => {
+            dispatcher.on( 'element:h5', ( evt, data, conversionApi ) => {
+                const { schema, writer } = conversionApi;
+
+                for ( const item of data.modelRange.getItems( { shallow: true } ) ) {
+                    const href = item.getAttribute( 'toc-link-href' );
+
+                    for ( const child of item.getChildren() ) {
+                        if ( child.is( 'text' ) ) {
+                            debugger;
+                            writer.setAttribute( 'linkHref', href, child );
+                        }
+                    }
+                }
+            } );
+        }, { priority: 'low' } );
 
         // <questionTitle> converters
         conversion.for( 'upcast' ).elementToElement( {

--- a/app/javascript/ckeditor/contentcommonediting.js
+++ b/app/javascript/ckeditor/contentcommonediting.js
@@ -113,7 +113,7 @@ export default class ContentCommonEditing extends Plugin {
         schema.register( 'answerTitle', {
             isLimit: true,
             allowIn: 'answer',
-            allowAttributes: [ 'id' ],
+            allowAttributes: [ 'id', 'toc-link-href' ],
             allowContentOf: '$block'
         } );
 
@@ -556,8 +556,10 @@ export default class ContentCommonEditing extends Plugin {
                 name: 'h5'
             },
             model: ( viewElement, modelWriter ) => {
+                const id = viewElement.getAttribute( 'id' ) || this._nextId();
                 return modelWriter.createElement( 'answerTitle', {
-                    'id': viewElement.getAttribute('id'),
+                    'id': id,
+                    'toc-link-href': '#' + id,
                 } );
             },
             // Use high priority to overwrite heading converters defined in
@@ -568,7 +570,7 @@ export default class ContentCommonEditing extends Plugin {
             model: 'answerTitle',
             view: ( modelElement, viewWriter ) => {
                 return viewWriter.createEditableElement( 'h5', {
-                    'id': modelElement.getAttribute( 'id' ),
+                    'id': modelElement.getAttribute( 'id' ) || this._nextId(),
                 } );
             },
             // Use high priority to overwrite heading converters defined in
@@ -579,7 +581,7 @@ export default class ContentCommonEditing extends Plugin {
             model: 'answerTitle',
             view: ( modelElement, viewWriter ) => {
                 const h5 = viewWriter.createEditableElement( 'h5', {
-                    'id': modelElement.getAttribute( 'id' ),
+                    'id': modelElement.getAttribute( 'id' ) || this._nextId(),
                 } );
 
                 enablePlaceholder( {

--- a/app/javascript/ckeditor/insertchecklistquestioncommand.js
+++ b/app/javascript/ckeditor/insertchecklistquestioncommand.js
@@ -21,7 +21,11 @@ export default class InsertChecklistQuestionCommand extends Command {
 function createChecklistQuestion( writer ) {
     const checklistQuestion = writer.createElement( 'moduleBlock' );
     const question = writer.createElement( 'question', {'data-grade-as': 'checklist'});
+
+    // TODO: Do I need to set the ID here? 
     const questionTitle = writer.createElement( 'questionTitle' );
+
+    
     const questionBody = writer.createElement( 'questionBody' );
     const questionForm = writer.createElement( 'questionForm' );
     const questionFieldset = writer.createElement( 'questionFieldset' );
@@ -60,6 +64,11 @@ function createChecklistQuestion( writer ) {
 
     // Return the created element and desired selection position.
     const selection = writer.createPositionAt( questionTitle, 0 );
+
+    //debugger;
+    //writer.setAttribute( 'id', 123, questionTitle );
+    writer.setAttribute( 'tocLinkHref', '#', questionTitle );
+
 
     return { checklistQuestion, selection };
 }

--- a/app/javascript/ckeditor/insertchecklistquestioncommand.js
+++ b/app/javascript/ckeditor/insertchecklistquestioncommand.js
@@ -21,11 +21,7 @@ export default class InsertChecklistQuestionCommand extends Command {
 function createChecklistQuestion( writer ) {
     const checklistQuestion = writer.createElement( 'moduleBlock' );
     const question = writer.createElement( 'question', {'data-grade-as': 'checklist'});
-
-    // TODO: Do I need to set the ID here? 
     const questionTitle = writer.createElement( 'questionTitle' );
-
-    
     const questionBody = writer.createElement( 'questionBody' );
     const questionForm = writer.createElement( 'questionForm' );
     const questionFieldset = writer.createElement( 'questionFieldset' );
@@ -64,11 +60,6 @@ function createChecklistQuestion( writer ) {
 
     // Return the created element and desired selection position.
     const selection = writer.createPositionAt( questionTitle, 0 );
-
-    //debugger;
-    //writer.setAttribute( 'id', 123, questionTitle );
-    writer.setAttribute( 'tocLinkHref', '#', questionTitle );
-
 
     return { checklistQuestion, selection };
 }

--- a/app/javascript/ckeditor/retaineddata.js
+++ b/app/javascript/ckeditor/retaineddata.js
@@ -38,9 +38,14 @@ export default class RetainedData extends Plugin {
 
         this._consumeAttributeEvent = this._consumeAttributeEvent.bind(this);
         this.getNextId = this.getNextId.bind(this);
+        this.getNextCount = this.getNextCount.bind(this);
 
         // Consume every attribute change event.
         editingDoc.listenTo( editingDoc.roots.first, 'change:attributes', this._consumeAttributeEvent );
+    }
+
+    getNextCount() {
+        return this._idCounter++;
     }
 
     getNextId() {

--- a/app/javascript/ckeditor/retaineddata.js
+++ b/app/javascript/ckeditor/retaineddata.js
@@ -14,7 +14,7 @@ const RETAINED_DATA_ATTRIBUTE = 'data-bz-retained';
  * - It listens to the view document for `change:attributes` events to look for new or changed
  *   retained data IDs. At initial page load, that means *all* IDs will be processed.
  * - It maintains an internal ID counter, which at page load is set to the highest previously used
- *   ID in the document, and is incremented every time `getNextId()` is called.
+ *   ID in the document, and is incremented every time `getNextId()` or `getNextCount()` is called.
  *
  * Points to note:
  *


### PR DESCRIPTION
**Task**: https://app.asana.com/0/1170776727341290/1170693002395753

**Test**

**Link on `<contentTitle>`**: check with `?debug` in model/view of CKE inspector
<img width="1775" alt="Screen Shot 2020-05-18 at 4 14 50 PM" src="https://user-images.githubusercontent.com/62911934/82268155-27459c80-9923-11ea-9969-0b77432979f3.png">

**Link on `<questionTitle>`**: check with `?debug` in model/view of CKE inspector
<img width="1758" alt="Screen Shot 2020-05-18 at 4 15 06 PM" src="https://user-images.githubusercontent.com/62911934/82268156-290f6000-9923-11ea-9dae-eaf825648c56.png">

**Link on `<answerTitle>`**: check in `Code` tab:
<img width="1792" alt="Screen Shot 2020-05-19 at 10 52 48 AM" src="https://user-images.githubusercontent.com/62911934/82361027-1b0f1d00-99bf-11ea-8c61-9515e8bffbc1.png">


**Published to `canvasweb`**: click and make sure anchor links work
*question and content titles are linked*
<img width="871" alt="Screen Shot 2020-05-18 at 4 15 21 PM" src="https://user-images.githubusercontent.com/62911934/82268158-2a408d00-9923-11ea-8140-1e81003d7916.png">
*answer title is linked*
<img width="1792" alt="Screen Shot 2020-05-19 at 10 52 34 AM" src="https://user-images.githubusercontent.com/62911934/82360991-0d599780-99bf-11ea-8b13-f93a87f9394d.png">

**Details**

- CKE gave us a solution here: https://github.com/ckeditor/ckeditor5/issues/6815
- The individual commits here a mess, but if you look at the `Files changed`, that should look sane. 
- We need to Save twice to get all the conversions to run to assign the `id` and `toc-link-href`, which isn't ideal. 
- The implementation steps are roughly:
-- Expose the counter from `retaineddata.js` so we can use it as a unique `id`
-- Make schema changes for `<contentTitle>` and `<questionTitle>` to allow attributes `id` and `toc-link-href`
-- On upcast/downcast conversions, propagate the `id` already on the element (in case we've already assigned it in a previous conversion or someone assigned on manually in the HTML). If there isn't one, get a unique one from `retaineddata` to use
-- On upcast for `<contentTitle>` and `<questionTitle>`, use that `id` to assign the `toc-link-href`, this is our attribute to let us know to link the text in these titles
-- Then we need to add a low-level `dispatcher` that listens on `element:h5`, to look for `toc-link-href` and attach the `linkHref` supported by CKE. 
-- I think roughly the same steps apply for our other headings, heading{1-5}, which map to `<h{2-6}>`. There might be a lot of boiler plate, but I'll see what I can refactor out. 