### PR TITLE
Fix slider answer attributes

### DIFF
--- a/app/javascript/ckeditor/insertsliderquestioncommand.js
+++ b/app/javascript/ckeditor/insertsliderquestioncommand.js
@@ -34,7 +34,6 @@ function createSliderQuestion( writer ) {
         'min': DEFAULT_MIN,
         'max': DEFAULT_MAX,
         'step': DEFAULT_STEP,
-        'data-bz-answer': DEFAULT_ANSWER,
         'data-bz-range-answer': DEFAULT_ANSWER,
     } );
     const displayValueDiv = writer.createElement( 'displayValueDiv' );

--- a/app/javascript/components/ContentEditor.js
+++ b/app/javascript/components/ContentEditor.js
@@ -527,8 +527,7 @@ class ContentEditor extends Component {
                                         return;
                                     }
 
-                                    const answer = selectedElement.getAttribute('data-bz-answer');
-                                    const rangeAnswer = selectedElement.getAttribute('data-bz-range-answer');
+                                    const answer = selectedElement.getAttribute('data-bz-range-answer');
 
                                     return (
                                         <>
@@ -568,10 +567,9 @@ class ContentEditor extends Component {
                                                 type='number'
                                                 id='input-answer'
                                                 value={answer}
-                                                disabled={!(answer || rangeAnswer)}
+                                                disabled={answer === undefined}
                                                 onChange={( evt ) => {
                                                     this.editor.execute( 'setAttributes', {
-                                                        'data-bz-answer': evt.target.value,
                                                         'data-bz-range-answer': evt.target.value,
                                                     } );
                                                 }}


### PR DESCRIPTION
Task: https://app.asana.com/0/1170776727341290/1176387214965594/f
Task: https://app.asana.com/0/1170776727341290/1173560888333813/f

We don't actually want data-bz-answer on all sliders, that attribute is only used for mastery questions.