### PR TITLE
Fix docker volume remove command

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ at `vendor/bundle` inside the container. If you attach to the container you can 
 some logging inside the gem code. You have to restart the container for the change to be picked up and if you 
 make a mess of things and want to blow it away you need to remove the vendor-bundle volume using:
 
-    docker-compose down -v vendor-bundle
+    docker volume rm platform_vendor-bundle
 
 **NOTE:** pry doesn't currently work with our setup. Need to figure that out.
 


### PR DESCRIPTION
`docker-compose down -v` doesn't take arguments, you have to use the docker command