### PR TITLE
Freeze bundle install in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /app
 ENV BUNDLE_PATH=/app/vendor/bundle
 
 COPY Gemfile Gemfile.lock /app/
-RUN bundle install --path vendor/bundle --jobs 4 && cp Gemfile.lock /tmp
+RUN bundle install --path vendor/bundle --jobs 4 --frozen && cp Gemfile.lock /tmp
 
 COPY . /app/
 


### PR DESCRIPTION
No task. We don't ever want the docker build to update the Gemfile.lock, as that defeats the purpose of having a lockfile: builds should be consistent and repeatable.