### PR TITLE
Add id and toc-link-href to h1-5

### DIFF
--- a/app/javascript/ckeditor/contentcommonediting.js
+++ b/app/javascript/ckeditor/contentcommonediting.js
@@ -166,28 +166,6 @@ export default class ContentCommonEditing extends Plugin {
         const editor = this.editor;
         const conversion = editor.conversion;
         const { editing, data, model } = editor;
-        
-        // Table of contents converters for titles
-        conversion.for( 'upcast' ).add( dispatcher => {
-            dispatcher.on( 'element:h5', ( evt, data, conversionApi ) => {
-                const { schema, writer } = conversionApi;
-
-                if (!data.modelRange) {
-                    return;
-                }
-
-                for ( const item of data.modelRange.getItems( { shallow: true } ) ) {
-                    const href = item.getAttribute( 'toc-link-href' );
-
-                    for ( const child of item.getChildren() ) {
-                        if ( child.is( 'text' ) ) {
-                            writer.setAttribute( 'linkHref', href, child );
-                            return;
-                        }
-                    }
-                }
-            } );
-        }, { priority: 'low' } );
 
         // <content> converters
         conversion.for( 'upcast' ).elementToElement( {

--- a/app/javascript/ckeditor/contentcommonediting.js
+++ b/app/javascript/ckeditor/contentcommonediting.js
@@ -167,7 +167,7 @@ export default class ContentCommonEditing extends Plugin {
         const conversion = editor.conversion;
         const { editing, data, model } = editor;
         
-        // Table of contents converters for <contentTitle> and <questionTitle>
+        // Table of contents converters for titles
         conversion.for( 'upcast' ).add( dispatcher => {
             dispatcher.on( 'element:h5', ( evt, data, conversionApi ) => {
                 const { schema, writer } = conversionApi;

--- a/app/javascript/ckeditor/customelementattributepreservation.js
+++ b/app/javascript/ckeditor/customelementattributepreservation.js
@@ -91,10 +91,11 @@ export default class CustomElementAttributePreservation extends Plugin {
             editor.conversion.for( 'upcast' ).elementToElement( {
                 view: key,
                 model: ( viewElement, modelWriter ) => {
-                    return modelWriter.createElement(
-                        elements[key],
-                        filterAllowedAttributes( viewElement.getAttributes() ),
-                    );
+                    let attributes = filterAllowedAttributes( viewElement.getAttributes() );
+                    if ( attributes.get( 'id' ) ) {
+                        attributes.set( 'toc-link-href', '#' + attributes.get( 'id' ) );
+                    }
+                    return modelWriter.createElement( elements[key], attributes );
                 },
             } );
 
@@ -105,7 +106,6 @@ export default class CustomElementAttributePreservation extends Plugin {
                     if ( !attributes.get( 'id' ) ) {
                         attributes.set( 'id', this._nextId() );
                     }
-                    attributes.set( 'toc-link-href', '#' + attributes.get( 'id' ) );
                     return viewWriter.createContainerElement( key, attributes );
                 },
             });

--- a/app/javascript/ckeditor/customelementattributepreservation.js
+++ b/app/javascript/ckeditor/customelementattributepreservation.js
@@ -1,6 +1,7 @@
 // See https://ckeditor.com/docs/ckeditor5/latest/framework/guides/deep-dive/conversion/conversion-preserving-custom-content.html#adding-extra-attributes-to-elements-contained-in-a-figure
 // and https://github.com/ckeditor/ckeditor5/issues/5569
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+import RetainedData from './retaineddata';
 
 export const ALLOWED_ATTRIBUTES = [
     'class',
@@ -27,18 +28,19 @@ export const ALLOWED_ATTRIBUTES = [
     'tabindex',
     'style',
     'align',
-]
+    'toc-link-href',
+];
 
 export default class CustomElementAttributePreservation extends Plugin {
     static get requires() {
-        return [ ];
+        return [ RetainedData ];
     }
 
     init() {
         const editor = this.editor;
 
         // Enable custom attributes on several predefined elements (see function).
-        setupAllowedAttributePreservation( editor );
+        this._setupAllowedAttributePreservation();
 
         // Enable custom class on tables, within figures.
         setupCustomFigureClassConversion( 'table', 'table', editor );
@@ -48,6 +50,148 @@ export default class CustomElementAttributePreservation extends Plugin {
         // Enable link extensions.
         allowLinkClass( editor );
         allowLinkRetainedData( editor );
+
+        // Set up shortcut to get unique id
+        this._nextId = editor.plugins.get('RetainedData').getNextCount;
+    }
+
+    // From https://ckeditor.com/docs/ckeditor5/latest/framework/guides/deep-dive/conversion/conversion-preserving-custom-content.html#loading-content-with-all-attributes
+    _setupAllowedAttributePreservation() {
+        const editor = this.editor;
+
+        // Allow <div> elements in the model.
+        editor.model.schema.register( 'div', {
+            allowWhere: '$block',
+            allowIn: [ 'questionFieldset', 'checkboxDiv' ],
+            allowContentOf: '$root'
+        } );
+
+        // Allow <span> elements in the model.
+        editor.model.schema.register( 'span', {
+            isInline: true,
+            allowWhere: '$block',
+            allowIn: '$block',
+            allowContentOf: '$block'
+        } );
+
+        // Elements we want to allow custom attribute preservation on.
+        // { view: model }
+        // Note: hN = heading(N-1) is a ckeditor5 convention.
+        // We can do all these with normal priority because the ones we define in ContentEditor.js
+        // in the CKE heading options are set to `low` priority.
+        const elements = {
+            'h2': 'heading1',
+            'h3': 'heading2',
+            'h4': 'heading3',
+            'h5': 'heading4',
+            'h6': 'heading5',
+        }
+
+        Object.keys( elements ).forEach( ( key ) => {
+            // View-to-model converter converting a view element with all its attributes to the model.
+            editor.conversion.for( 'upcast' ).elementToElement( {
+                view: key,
+                model: ( viewElement, modelWriter ) => {
+                    const id = viewElement.getAttribute( 'id' ) || this._nextId();
+                    return modelWriter.createElement( elements[key], {
+                        'id': id,
+                        'toc-link-href': '#' + id,
+                        ...filterAllowedAttributes( viewElement.getAttributes() ),
+                    } );
+                },
+            } );
+
+            // Table of contents converter for headings
+            editor.conversion.for( 'upcast' ).add( dispatcher => {
+                dispatcher.on( 'element:' + key, ( evt, data, conversionApi ) => {
+                    const { schema, writer } = conversionApi;
+
+                    if (!data.modelRange) {
+                        return;
+                    }
+                    
+                    for ( const item of data.modelRange.getItems( { shallow: true } ) ) {
+                        const href = item.getAttribute('toc-link-href');
+                        for ( const child of item.getChildren() ) {
+                            if ( child.is( 'text' ) ) {
+                                writer.setAttribute( 'linkHref', href, child);
+                                return;
+                            }
+                        }
+                    }
+                } );
+            } );
+        } );
+
+        // Paragraph and converter must be high priority so it overrides the CKE builtin converters.
+        editor.conversion.for( 'upcast' ).elementToElement( {
+            view: 'p',
+            model: ( viewElement, modelWriter ) => {
+                return modelWriter.createElement( 'paragraph', filterAllowedAttributes( viewElement.getAttributes() ) );
+            },
+            // Use high priority because the 'low' we defined for the cke paragraph converter in ContentEditor.js doesn't
+            // work for some reason.
+            converterPriority: 'high'
+        } );
+        editor.conversion.for( 'upcast' ).elementToElement( {
+            view: 'td',
+            model: ( viewElement, modelWriter ) => {
+                return modelWriter.createElement( 'tableCell', filterAllowedAttributes( viewElement.getAttributes() ) );
+            },
+            // Use low priority to make sure existing converters run first.
+            converterPriority: 'high'
+        } );
+
+        // Div and span converters must be normal priority or lower so they don't override more specific converters defined elsewhere.
+        editor.conversion.for( 'upcast' ).elementToElement( {
+            view: 'div',
+            model: ( viewElement, modelWriter ) => {
+                return modelWriter.createElement( 'div', filterAllowedAttributes( viewElement.getAttributes() ) );
+            },
+        } );
+        editor.conversion.for( 'upcast' ).elementToElement( {
+            view: 'span',
+            model: ( viewElement, modelWriter ) => {
+                return modelWriter.createElement( 'span', filterAllowedAttributes( viewElement.getAttributes() ) );
+            },
+            // Use low priority to make sure existing converters run first.
+            converterPriority: 'low'
+        } );
+
+        // Model-to-view converter for the <div> element (attrbiutes are converted separately).
+        editor.conversion.for( 'downcast' ).elementToElement( {
+            model: 'div',
+            view: 'div'
+        } );
+
+        // Model-to-view converter for the <span> element (attrbiutes are converted separately).
+        editor.conversion.for( 'downcast' ).elementToElement( {
+            model: 'span',
+            view: 'span'
+        } );
+
+        // Model-to-view converter for all element attributes.
+        // Note that a lower-level, event-based API is used here.
+        editor.conversion.for( 'downcast' ).add( dispatcher => {
+            dispatcher.on( 'attribute', ( evt, data, conversionApi ) => {
+                // Allow all elements in the model to have any of a preset list of attributes.
+                if ( ! ALLOWED_ATTRIBUTES.includes( data.attributeKey ) ) {
+                    return;
+                }
+
+                const viewWriter = conversionApi.writer;
+                const viewElement = conversionApi.mapper.toViewElement( data.item );
+
+                // In the model-to-view conversion we convert changes.
+                // An attribute can be added or removed or changed.
+                // The below code handles all 3 cases.
+                if ( data.attributeNewValue ) {
+                    viewWriter.setAttribute( data.attributeKey, data.attributeNewValue, viewElement );
+                } else {
+                    viewWriter.removeAttribute( data.attributeKey, viewElement );
+                }
+            } );
+        } );
     }
 }
 
@@ -164,117 +308,7 @@ function downcastAttribute( modelElementName, viewElementName, viewAttribute, mo
     } );
 }
 
-// From https://ckeditor.com/docs/ckeditor5/latest/framework/guides/deep-dive/conversion/conversion-preserving-custom-content.html#loading-content-with-all-attributes
-function setupAllowedAttributePreservation( editor ) {
-    // Allow <div> elements in the model.
-    editor.model.schema.register( 'div', {
-        allowWhere: '$block',
-        allowIn: [ 'questionFieldset', 'checkboxDiv' ],
-        allowContentOf: '$root'
-    } );
 
-    // Allow <span> elements in the model.
-    editor.model.schema.register( 'span', {
-        isInline: true,
-        allowWhere: '$block',
-        allowIn: '$block',
-        allowContentOf: '$block'
-    } );
-
-    // Elements we want to allow custom attribute preservation on.
-    // { view: model }
-    // Note: hN = heading(N-1) is a ckeditor5 convention.
-    // We can do all these with normal priority because the ones we define in ContentEditor.js
-    // in the CKE heading options are set to `low` priority.
-    const elements = {
-        'h2': 'heading1',
-        'h3': 'heading2',
-        'h4': 'heading3',
-        'h5': 'heading4',
-        'h6': 'heading5',
-    }
-
-    Object.keys( elements ).forEach( ( key ) => {
-        // View-to-model converter converting a view element with all its attributes to the model.
-        editor.conversion.for( 'upcast' ).elementToElement( {
-            view: key,
-            model: ( viewElement, modelWriter ) => {
-                return modelWriter.createElement( elements[key], filterAllowedAttributes( viewElement.getAttributes() ) );
-            },
-        } );
-    } );
-
-    // Paragraph and converter must be high priority so it overrides the CKE builtin converters.
-    editor.conversion.for( 'upcast' ).elementToElement( {
-        view: 'p',
-        model: ( viewElement, modelWriter ) => {
-            return modelWriter.createElement( 'paragraph', filterAllowedAttributes( viewElement.getAttributes() ) );
-        },
-        // Use high priority because the 'low' we defined for the cke paragraph converter in ContentEditor.js doesn't
-        // work for some reason.
-        converterPriority: 'high'
-    } );
-    editor.conversion.for( 'upcast' ).elementToElement( {
-        view: 'td',
-        model: ( viewElement, modelWriter ) => {
-            return modelWriter.createElement( 'tableCell', filterAllowedAttributes( viewElement.getAttributes() ) );
-        },
-        // Use low priority to make sure existing converters run first.
-        converterPriority: 'high'
-    } );
-
-    // Div and span converters must be normal priority or lower so they don't override more specific converters defined elsewhere.
-    editor.conversion.for( 'upcast' ).elementToElement( {
-        view: 'div',
-        model: ( viewElement, modelWriter ) => {
-            return modelWriter.createElement( 'div', filterAllowedAttributes( viewElement.getAttributes() ) );
-        },
-    } );
-    editor.conversion.for( 'upcast' ).elementToElement( {
-        view: 'span',
-        model: ( viewElement, modelWriter ) => {
-            return modelWriter.createElement( 'span', filterAllowedAttributes( viewElement.getAttributes() ) );
-        },
-        // Use low priority to make sure existing converters run first.
-        converterPriority: 'low'
-    } );
-
-    // Model-to-view converter for the <div> element (attrbiutes are converted separately).
-    editor.conversion.for( 'downcast' ).elementToElement( {
-        model: 'div',
-        view: 'div'
-    } );
-
-    // Model-to-view converter for the <span> element (attrbiutes are converted separately).
-    editor.conversion.for( 'downcast' ).elementToElement( {
-        model: 'span',
-        view: 'span'
-    } );
-
-    // Model-to-view converter for all element attributes.
-    // Note that a lower-level, event-based API is used here.
-    editor.conversion.for( 'downcast' ).add( dispatcher => {
-        dispatcher.on( 'attribute', ( evt, data, conversionApi ) => {
-
-            // Allow all elements in the model to have any of a preset list of attributes.
-            if ( ! ALLOWED_ATTRIBUTES.includes( data.attributeKey ) ) {
-                return;
-            }
-
-            const viewWriter = conversionApi.writer;
-            const viewElement = conversionApi.mapper.toViewElement( data.item );
-
-            // In the model-to-view conversion we convert changes.
-            // An attribute can be added or removed or changed.
-            // The below code handles all 3 cases.
-            if ( data.attributeNewValue ) {
-                viewWriter.setAttribute( data.attributeKey, data.attributeNewValue, viewElement );
-            } else {
-                viewWriter.removeAttribute( data.attributeKey, viewElement );
-            }
-        } );
-    } );
-}
 
 // Filter out attributes that aren't in ALLOWED_ATTRIBUTES.
 // Return a map of key:value pairs as expected by createElement.

--- a/app/javascript/ckeditor/customelementattributepreservation.js
+++ b/app/javascript/ckeditor/customelementattributepreservation.js
@@ -91,12 +91,10 @@ export default class CustomElementAttributePreservation extends Plugin {
             editor.conversion.for( 'upcast' ).elementToElement( {
                 view: key,
                 model: ( viewElement, modelWriter ) => {
-                    let attributes = filterAllowedAttributes( viewElement.getAttributes() );
-                    if ( !attributes.get( 'id' ) ) {
-                        attributes.set( 'id', this._nextId() );
-                    }
-                    attributes.set( 'toc-link-href', '#' + attributes.get( 'id' ) );
-                    return modelWriter.createElement( elements[key], attributes );
+                    return modelWriter.createElement(
+                        elements[key],
+                        filterAllowedAttributes( viewElement.getAttributes() ),
+                    );
                 },
             } );
 
@@ -107,6 +105,7 @@ export default class CustomElementAttributePreservation extends Plugin {
                     if ( !attributes.get( 'id' ) ) {
                         attributes.set( 'id', this._nextId() );
                     }
+                    attributes.set( 'toc-link-href', '#' + attributes.get( 'id' ) );
                     return viewWriter.createContainerElement( key, attributes );
                 },
             });

--- a/app/javascript/ckeditor/retaineddata.js
+++ b/app/javascript/ckeditor/retaineddata.js
@@ -55,7 +55,17 @@ export default class RetainedData extends Plugin {
     _consumeAttributeEvent( evt, elem ) {
         for ( let attribute of elem.getAttributeKeys() ) {
 
-            // Ignore all but retained data IDs.
+            // ID
+            if ( attribute === 'id' ) {
+                const value = elem.getAttribute( 'id' );
+                // Assume if it's an integer value, we could have assigned it
+                if ( !isNaN( value ) ) {
+                    this._idCounter = Math.max( parseInt(value) + 1, this._idCounter );
+                }
+                break;
+            }
+
+            // Retained data ID
             if ( attribute === RETAINED_DATA_ATTRIBUTE ) {
                 const value = elem.getAttribute( attribute );
 

--- a/app/javascript/ckeditor/retaineddata.js
+++ b/app/javascript/ckeditor/retaineddata.js
@@ -53,34 +53,19 @@ export default class RetainedData extends Plugin {
     }
 
     _consumeAttributeEvent( evt, elem ) {
-        for ( let attribute of elem.getAttributeKeys() ) {
+        // Check for retained data ID and only handle ones that match our prefix
+        const retainedDataId = elem.getAttribute( RETAINED_DATA_ATTRIBUTE );
+        if ( retainedDataId && retainedDataId.startsWith( this._retainedDataPrefix ) ) {
+            const id = parseInt( retainedDataId.split( this._retainedDataPrefix ).pop() );
+            // If retained data ID is larger than current count, set count to data ID + 1
+            // Otherwise, keep the current count
+            this._idCounter = Math.max( id + 1, this._idCounter );
+        }
 
-            // ID
-            if ( attribute === 'id' ) {
-                const value = elem.getAttribute( 'id' );
-                // Assume if it's an integer value, we could have assigned it
-                if ( !isNaN( value ) ) {
-                    this._idCounter = Math.max( parseInt(value) + 1, this._idCounter );
-                }
-                break;
-            }
-
-            // Retained data ID
-            if ( attribute === RETAINED_DATA_ATTRIBUTE ) {
-                const value = elem.getAttribute( attribute );
-
-                // Ignore all but retained data IDs that match our per-page prefix.
-                if ( value.startsWith( this._retainedDataPrefix ) ) {
-                    const idIntegerPart = parseInt( value.split( this._retainedDataPrefix ).pop() );
-
-                    // If this ID is greater than our current counter, set the counter to this ID + 1.
-                    // Otherwise, ignore it.
-                    this._idCounter = Math.max( idIntegerPart + 1, this._idCounter );
-                }
-
-                // Once we hit the retained data attribute, exit early.
-                break;
-            }
+        // Check for ID and handle numeric ones so we don't collide with existing ones
+        const id = elem.getAttribute( 'id' );
+        if ( id && !isNaN( id ) ) {
+            this._idCounter = Math.max( parseInt(id) + 1, this._idCounter );
         }
     }
 }


### PR DESCRIPTION
**Task**: https://app.asana.com/0/1170776727341290/1176606860502193

**Test**

Manually type some text, highlight and set heading in drop-down:
<img width="1478" alt="Screen Shot 2020-05-19 at 3 10 24 PM" src="https://user-images.githubusercontent.com/62911934/82383542-e0b77700-99e2-11ea-835f-403f586fc860.png">

Toggle between Design/Code and check with `?debug` in CKE inspector that `id` and `toc-link-href` are being set:
<img width="1784" alt="Screen Shot 2020-05-19 at 2 57 15 PM" src="https://user-images.githubusercontent.com/62911934/82383484-c1204e80-99e2-11ea-9ad5-78b930e29fe0.png">

Publish to `canvasweb` and check that table of contents is generated properly:
<img width="1121" alt="Screen Shot 2020-05-19 at 2 59 18 PM" src="https://user-images.githubusercontent.com/62911934/82383621-13616f80-99e3-11ea-8137-ce5be29b3ca8.png">

To test the anchor links, I padded out with some questions & answers to make the browser scroll. I also made sure the `<h5>` from the `<{question, answer, content}Title>`s weren't showing up in the table of contents:
<img width="1782" alt="Screen Shot 2020-05-19 at 3 01 13 PM" src="https://user-images.githubusercontent.com/62911934/82383659-21af8b80-99e3-11ea-93d7-4e83260c12aa.png">

Made sure that merging of attributes works by manually changing code to add `class=jess-test` on a heading: 
<img width="1792" alt="Screen Shot 2020-05-19 at 3 01 45 PM" src="https://user-images.githubusercontent.com/62911934/82383740-44da3b00-99e3-11ea-9547-391194463e3c.png">

Go back to `Design` and make sure it's still in the model:
<img width="1792" alt="Screen Shot 2020-05-19 at 3 01 53 PM" src="https://user-images.githubusercontent.com/62911934/82383764-502d6680-99e3-11ea-957e-5cba4ab62914.png">

**Details**

- Need to update `retaineddata`'s `_consumeAttributeEvent()` to look for `id`, in addition to our retained data ID to initialize the id counter. 
- Need **both** an upcast and downcast to call `_getNextId()` in order for `retaineddata` to increment properly. See comment in code. 