### PR TITLE
Remove default ID from Title element upcasts

### DIFF
--- a/app/javascript/ckeditor/contentcommonediting.js
+++ b/app/javascript/ckeditor/contentcommonediting.js
@@ -241,7 +241,7 @@ export default class ContentCommonEditing extends Plugin {
                 name: 'h5'
             },
             model: ( viewElement, modelWriter ) => {
-                const id = viewElement.getAttribute( 'id' ) || this._nextId();
+                const id = viewElement.getAttribute( 'id' );
                 return modelWriter.createElement( 'contentTitle', {
                     'id': id,
                     'toc-link-href': '#' + id,
@@ -358,7 +358,7 @@ export default class ContentCommonEditing extends Plugin {
                 name: 'h5'
             },
             model: ( viewElement, modelWriter ) => {
-                const id = viewElement.getAttribute('id') || this._nextId();
+                const id = viewElement.getAttribute('id');
                 return modelWriter.createElement( 'questionTitle', {
                     'id': id,
                     'toc-link-href': '#' + id,
@@ -580,7 +580,7 @@ export default class ContentCommonEditing extends Plugin {
                 name: 'h5'
             },
             model: ( viewElement, modelWriter ) => {
-                const id = viewElement.getAttribute( 'id' ) || this._nextId();
+                const id = viewElement.getAttribute( 'id' );
                 return modelWriter.createElement( 'answerTitle', {
                     'id': id,
                     'toc-link-href': '#' + id,


### PR DESCRIPTION
Fixes a bug where title h5s are assigned a possibly non-unique ID, because upcast runs before the RetainedData plugin has enumerated existing IDs. No task.