### PR TITLE
Remove the vendor/bundle volume on rebuild.

### DIFF
--- a/docker-compose/scripts/rebuild.sh
+++ b/docker-compose/scripts/rebuild.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
-docker-compose down 
+docker-compose down
+docker volume rm platform_vendor-bundle
 docker-compose up -d --force-recreate --build


### PR DESCRIPTION
A rebuild should get you in a clean state. The volume may have old gems
and stuff, so go ahead and remove it on rebuild to get back to a pristine condition.

Test Plan:
- run: docker-compose/scripts/rebuild.sh and make sure it builds and you can
  still login / use the platform