### PR TITLE
Show error message if user tries to login before confirming account.

### DIFF
--- a/app/controllers/cas_controller.rb
+++ b/app/controllers/cas_controller.rb
@@ -189,10 +189,15 @@ class CasController < ApplicationController
           end
         end
       else
-        logger.warn("Invalid credentials given for user '#{@username}'")
-        @message = {
-          :type => 'mistake', :message => "Incorrect username or password."
-        }
+        user = User.find_by_email(@username)
+        unconfirmed_user = user && user.confirmed? == false
+        if unconfirmed_user
+          logger.warn("Unconfirmed user tried to login: '#{@username}'")
+          @message = { :type => 'mistake', :message => "Please confirm your account by clicking on the link in the email you received first." }
+        else
+          logger.warn("Invalid credentials given for user '#{@username}'")
+          @message = { :type => 'mistake', :message => "Incorrect username or password." }
+        end
         return render :login, status: :unauthorized
       end
     rescue RubyCAS::Server::Core::AuthenticatorError => e

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -55,7 +55,12 @@ class User < ApplicationRecord
   def full_name
     [first_name, last_name].join(' ')
   end
-  
+
+  # True if the user has confirmed their account and can login.  
+  def confirmed?
+    !!confirmed_at
+  end
+
   def start_membership(program_id, role_id)
     find_membership(program_id, role_id) ||
       program_memberships.create(program_id: program_id, role_id: role_id, start_date: Date.today)

--- a/lib/cas_authenticator.rb
+++ b/lib/cas_authenticator.rb
@@ -4,9 +4,8 @@ module BravenCAS
 
     def validate(credentials)
       @user = User.find_by_email!(credentials[:username])
-      # TODO: check whether they are confirmed as well and clean this up.
       #valid_password?(credentials[:password]) && active_for_authentication?
-      valid_password?(credentials[:password])
+      valid_password?(credentials[:password]) && @user.confirmed?
     rescue ActiveRecord::RecordNotFound
       false
     end
@@ -15,14 +14,6 @@ module BravenCAS
       return false if @user.encrypted_password.blank?
       BCrypt::Password.new(@user.encrypted_password) == password
     end
-
-#  def active_for_authentication?
-#    !@user.inactive && @user.confirmed?
-#  end
-#
-#  def confirmed?
-#    !!@user.confirmed_at
-#  end
 
   end
 end


### PR DESCRIPTION
See: https://app.asana.com/0/1170770467635599/1172738433561916

Test Plan:
- Register a new user but don't click the confirmation link. Try to login.
  You should get a message about needing to confirm first.
- Confirm the user, then try a bad password. You should get a message about
  a bad username or password.
- Then make sure you can login.