### PR TITLE
On a non Booster server, add a link to the Booster login.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 APPLICATION_HOST=platformweb
+BOOSTER_PORTAL_DOMAIN=boosterweb
 # Toggle this on to switch to the old CAS authentication agains the Join server
 #BZ_AUTH_SERVER=joinweb
 CANVAS_URL=http://canvasweb:3000/

--- a/app/assets/stylesheets/accounts.scss
+++ b/app/assets/stylesheets/accounts.scss
@@ -1280,3 +1280,14 @@ li > ul {
 		font-size: 10pt;
 	}
 }
+
+#booster-login {
+    font-size: 1.2em;
+}
+
+#booster-login a {
+	color: black;
+	text-decoration: underline;
+	font-weight: bold;
+}
+

--- a/app/views/cas/login.html.erb
+++ b/app/views/cas/login.html.erb
@@ -17,3 +17,10 @@
   <%= render "login_form" %>
 </div>
 
+<% if ENV['APPLICATION_HOST'].exclude? 'booster'  %>
+<div class="col-md-6 col-md-offset-4" id="booster-login">
+  For the Braven Career Booster: <a href="//<%= @settings[:booster_portal_domain] %>">Login here</a>
+</div>
+<% end %>
+
+

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -74,6 +74,7 @@ Rails.application.configure do
   # communicate across containers. This line allows connection via the
   # specified name.
   config.hosts << "platformweb"
+  config.hosts << "boosterplatformweb"
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/config/rubycas.yml
+++ b/config/rubycas.yml
@@ -8,6 +8,7 @@ default: &default
   log:
     output:
     level: INFO
+  booster_portal_domain: <%= ENV['BOOSTER_PORTAL_DOMAIN'] %>
   public_site_domain: <%= ENV['PUBLIC_SITE_DOMAIN'] %>
   database: &default_db
     database: platform
@@ -38,6 +39,7 @@ development: &development_config
   log:
     output: 
     level: DEBUG
+  booster_portal_domain: boosterweb
   public_site_domain: joinweb
   # this should be the *top* domain - so even for staging, it should be .join.bebraven.org stilldefault_service: http://canvasweb/login/cas
   cookie_domain: .localhost 


### PR DESCRIPTION
**Note: when releasing this, make sure and set the BOOSTER_PORTAL_DOMAIN env var**

If folks don't bookmark the booster login link and just google
Braven, they'll likely end up at https://bebraven.org and hit
Log In at the top-right. That will bring them to the normal
Accelerator login. On that server, this commit adds a link to login
to the Booster portal if that's what they were looking for.

See: https://app.asana.com/0/1170770467635599/1173563708676233

### Test Plan
- Go to the login page with APPLICATION_HOST set to something with
  booster in it and the link shouldn't be there. Change the APPLICATION_HOST
  to something without booster in it and the link to login to Booster should
  show up on the login page.