### PR TITLE
Fix Course Copy on the Portal side of things.

### DIFF
--- a/lib/canvas_api.rb
+++ b/lib/canvas_api.rb
@@ -9,8 +9,8 @@ class CanvasAPI
   # We also wrap the entire contents in a "bz-module" div, so the CSS selectors
   # work as expected.
   PrependHTML = %q(
-    <!-- BRAVEN_NEW_HTML -->
     <div class="bz-module">
+    <!-- BRAVEN_NEW_HTML -->
   )
 
   # Custom HTML to append to each body.

--- a/spec/lib/canvas_api_spec.rb
+++ b/spec/lib/canvas_api_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe CanvasAPI do
       canvas.update_course_page(1, 'test', 'test-body')
 
       expect(WebMock).to have_requested(:put, "#{CANVAS_API_URL}/courses/1/pages/test").
-        with(body: 'wiki_page%5Bbody%5D=%0A++++%3C%21--+BRAVEN_NEW_HTML+--%3E%0A++++%3Cdiv+class%3D%22bz-module%22%3E%0A++test-body%0A++++%3C%2Fdiv%3E%0A++').once
+        with(body: 'wiki_page%5Bbody%5D=%0A++++%3Cdiv+class%3D%22bz-module%22%3E%0A++++%3C%21--+BRAVEN_NEW_HTML+--%3E%0A++test-body%0A++++%3C%2Fdiv%3E%0A++').once
     end
   end
 


### PR DESCRIPTION
This is dumb, but when we do course copy or content import in the Portal,
it strips out the leading comments. Nested comments inside the div work.
The JS doesn't care where this token is.

See: https://app.asana.com/0/1170770467635599/1178021488868222

### Test Plan:
- Push content to Portal. Copy the course with the content and make sure in the
  copied course the BRAVEN_NEW_HTML token is in the HTML and the new JS and CSS
  runs/is applied.