### PR TITLE
Add slack integration to the rake task to sync Student Waivers.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,15 @@
 GIT
   remote: https://github.com/bebraven/rowan_bot.git
-  revision: 467f1f8a0fefd296ffac2a54750a13f5f930dd1a
+  revision: c22f662df2b7b2b5105bea9f05591f6802cf4250
   branch: master
   specs:
     rowan_bot (0.1.0)
+      capybara
       docusign_esign
       faraday
       restforce (~> 4.2.2)
+      selenium-webdriver
+      slack-ruby-client
 
 GIT
   remote: https://github.com/bebraven/rubycas-server-core.git
@@ -102,7 +105,7 @@ GEM
     childprocess (3.0.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.6)
-    connection_pool (2.2.2)
+    connection_pool (2.2.3)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.6)
@@ -150,6 +153,7 @@ GEM
       ffi (>= 1.0.0)
       rake
     formatador (0.2.5)
+    gli (2.19.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     guard (2.16.2)
@@ -390,6 +394,13 @@ GEM
     simplecov-cobertura (1.3.1)
       simplecov (~> 0.8)
     simplecov-html (0.12.2)
+    slack-ruby-client (0.14.6)
+      activesupport
+      faraday (>= 0.9)
+      faraday_middleware
+      gli
+      hashie
+      websocket-driver
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)


### PR DESCRIPTION
Note the ENV vars that need to be set in production for this to work.

Test Plan:
- Invite a Particpant to signup. Signup and sign DocuSign. Then run bundle exec rake sync:docusign_to_salesforce and in addition to the Student Waiver SIgned field being updated in Salesforce, they should be invited to join the Slack channel for their peer group