### PR TITLE
Nicer error messages when creating an account.

### DIFF
--- a/app/assets/stylesheets/accounts.scss
+++ b/app/assets/stylesheets/accounts.scss
@@ -593,6 +593,14 @@ label {
   margin: 0 0 10px;
 }
 
+// Uncomment to have activerecord validation failures add a red border around the field.
+// Right now, we only have the password creation form which we would want to turn this off
+// for since it's only two fields there and they don't need to be highlighted.
+// See: app/views/devise/registrations/new.html.erb 
+//.field_with_errors input {
+//  border: 2px solid red;
+//}
+
 .form-control {
 	display: block;
 	width: 100%;
@@ -1037,6 +1045,14 @@ form {
 	vertical-align: baseline;
 }
 
+#error_explanation li {
+	color: red;
+}
+
+#error_explanation h3 {
+	margin-top: 0px;
+}
+
 #topheader {
 	background-color: #ffffff;
 	height: 60px;
@@ -1290,4 +1306,3 @@ li > ul {
 	text-decoration: underline;
 	font-weight: bold;
 }
-

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -9,15 +9,17 @@
     <%= render "devise/shared/error_messages", resource: resource %>
 
     <div class="field">
-      <%= f.label :password %>
-      <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em>
-      <% end %><br />
+      <%= f.label :password do %>
+        Password
+        <% if @minimum_password_length %>
+        <em>(<%= @minimum_password_length %> characters minimum)</em>
+        <% end %>
+      <% end %>
       <%= f.password_field :password, class: 'form-control', required: true, autocomplete: "new-password" %>
     </div>
   
     <div class="field">
-      <%= f.label :password_confirmation %><br />
+      <%= f.label :password_confirmation %>
       <%= f.password_field :password_confirmation, class: 'form-control', required: true, autocomplete: "new-password" %>
     </div>
     <br/>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,15 +1,11 @@
 <% if resource.errors.any? %>
   <div id="error_explanation">
-    <h2>
-      <%= I18n.t("errors.messages.not_saved",
-                 count: resource.errors.count,
-                 resource: resource.class.model_name.human.downcase)
-       %>
-    </h2>
+    <h3>
+      Please try again.
+    </h3>
     <ul>
-      <% resource.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
+      <%# Only show the first error and let them work through them one at a time %>
+      <li><%= resource.errors.first[1] %></li>
     </ul>
   </div>
 <% end %>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,7 +1,7 @@
 <% if resource.errors.any? %>
   <div id="error_explanation">
     <h3>
-      Please try again.
+      Please try again
     </h3>
     <ul>
       <%# Only show the first error and let them work through them one at a time %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,3 +31,19 @@
 
 en:
   hello: "Hello world"
+  activerecord:
+    errors:
+      models:
+        user:
+          attributes:
+            email:
+              taken: "Looks like you've already signed up. Please log-in instead."
+            password:
+              blank: "Please enter a password"
+              confirmation: "Passwords don't match"
+              too_short: "Password is too short"
+            password_confirmation:
+              blank: "Please enter a password confirmation"
+              confirmation: "Passwords don't match"
+              too_short: "Password is too short"
+


### PR DESCRIPTION
See: https://app.asana.com/0/1170770467635599/1175130656011747

### Test Plan:
- Signup with mismatching passwords, with passwords too short, and with
  and existing user. Only one error messaage should be shown and if you
  keep making errors the signup form should still look the same. just with
  the current errror shown