### PR TITLE
Add check if enrolments is an array

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -128,7 +128,7 @@ class User < ApplicationRecord
   def setup_canvas_access
     return if canvas_id
     existing_user = CanvasAPI.client.find_user_in_canvas(email)
-    if existing_user && false
+    if existing_user
       self.canvas_id = existing_user['id']
     else
       Rails.logger.info("Creating Canvas account and enrollments for new user: #{inspect}")

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -105,8 +105,10 @@ class User < ApplicationRecord
   # Handles anything that should happen when a new account is being registered
   # using the new_user_registration route
   def do_account_registration
+    Rails.logger.info('Starting account registration')
     if sync_salesforce_info # They can't register for Canvas access if they aren't Enrolled in Salesforce
       setup_canvas_access
+      Rails.logger.info('Done setting up canvas access')
       store_canvas_id_in_salesforce
     end
   end
@@ -126,7 +128,7 @@ class User < ApplicationRecord
   def setup_canvas_access
     return if canvas_id
     existing_user = CanvasAPI.client.find_user_in_canvas(email)
-    if existing_user
+    if existing_user && false
       self.canvas_id = existing_user['id']
     else
       Rails.logger.info("Creating Canvas account and enrollments for new user: #{inspect}")

--- a/lib/sync_to_lms.rb
+++ b/lib/sync_to_lms.rb
@@ -146,6 +146,10 @@ class SyncToLMS
     end
     section_id = section['id']
 
+    if existing_enrollment.is_a? Array
+      existing_enrollment = existing_enrollment.last
+    end
+
     if existing_enrollment && existing_enrollment['course_section_id'] != section_id
       Rails.logger.debug("Moving canvas_user_id = #{canvas_user_id} in course_id = #{course_id} from section_id = #{existing_enrollment['course_section_id']} to a new one")
       @canvas_api.cancel_enrollment(existing_enrollment)


### PR DESCRIPTION
There was an error if a user has enrolments. This is caused by a check that assumes enrolments will be returned as an object. This PR:

- [x] Fetches the last enrolment for the check
- [x] Adds some log info for debugging
- [x] Ensures canvas check on user sign up