### PR TITLE
Ensure that all new sign creates go through canvas setup

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -128,19 +128,8 @@ class User < ApplicationRecord
   def setup_canvas_access
     return if canvas_id
 
-    Rails.logger.info("Creating Canvas account and enrollments for new user: #{inspect}")
+    Rails.logger.info("Setting up Canvas account and enrollments for user: #{inspect}")
     self.canvas_id = SyncToLMS.new.for_contact(salesforce_id)
-
-    # Stopping this short circuit so returning user can go through the canvas
-    # process again
-    #
-    # existing_user = CanvasAPI.client.find_user_in_canvas(email)
-    # if existing_user
-    #   self.canvas_id = existing_user['id']
-    # else
-    #   Rails.logger.info("Creating Canvas account and enrollments for new user: #{inspect}")
-    #   self.canvas_id = SyncToLMS.new.for_contact(salesforce_id)
-    # end
   end
 
   def store_canvas_id_in_salesforce

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -127,13 +127,20 @@ class User < ApplicationRecord
   # Looks up their Canvas account and sets the Id so that on login we can redirect them there.
   def setup_canvas_access
     return if canvas_id
-    existing_user = CanvasAPI.client.find_user_in_canvas(email)
-    if existing_user
-      self.canvas_id = existing_user['id']
-    else
-      Rails.logger.info("Creating Canvas account and enrollments for new user: #{inspect}")
-      self.canvas_id = SyncToLMS.new.for_contact(salesforce_id)
-    end
+
+    Rails.logger.info("Creating Canvas account and enrollments for new user: #{inspect}")
+    self.canvas_id = SyncToLMS.new.for_contact(salesforce_id)
+
+    # Stopping this short circuit so returning user can go through the canvas
+    # process again
+    #
+    # existing_user = CanvasAPI.client.find_user_in_canvas(email)
+    # if existing_user
+    #   self.canvas_id = existing_user['id']
+    # else
+    #   Rails.logger.info("Creating Canvas account and enrollments for new user: #{inspect}")
+    #   self.canvas_id = SyncToLMS.new.for_contact(salesforce_id)
+    # end
   end
 
   def store_canvas_id_in_salesforce

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -76,12 +76,21 @@ RSpec.describe User, type: :model do
       end   
     end
 
-    # Skipping this because this is not valid anymore.
-    xcontext 'when canvas user exists' do
+    context 'when canvas user exists' do
+      let(:participants) { build_list(:salesforce_participant_fellow, 1, Email: sf_contact['Email']) }
+      let(:sf_program) { build(:salesforce_program_record) }
+      let(:section) { build(:canvas_section) }
+      let(:enrollment) { build(:canvas_enrollment_student) }
+
       it 'sets the canvas_id' do
         allow(sf_api_client).to receive(:get_contact_info).and_return(sf_contact)
+        allow(sf_api_client).to receive(:get_participants).and_return(participants)
+        allow(sf_api_client).to receive(:get_program_info).and_return(sf_program)
         allow(sf_api_client).to receive(:set_canvas_id).and_return(nil)
+        allow(canvas_api_client).to receive(:create_section).and_return(section)
+
         expect(canvas_api_client).to receive(:find_user_in_canvas).with(sf_contact['Email']).and_return(canvas_user).once
+        expect(canvas_api_client).to receive(:enroll_user_in_course).with(canvas_user['id'], any_args).and_return(enrollment).once
         user = create :user, salesforce_id: sf_contact['Id'], password: 'somepassword'
         user = user.reload
         expect(user.canvas_id).to eq(canvas_user['id'])

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -51,10 +51,10 @@ RSpec.describe User, type: :model do
     end
 
     context "when salesforce_id is set" do
- 
       it 'email and name are fetched from the salesforce_api and set' do
         allow(canvas_api_client).to receive(:find_user_in_canvas).and_return(canvas_user)
         allow(sf_api_client).to receive(:set_canvas_id).and_return(nil)
+        allow(sf_api_client).to receive(:get_participants).and_return([])
         expect(sf_api_client).to receive(:get_contact_info).with(sf_contact['Id']).and_return(sf_contact).once
         user = create :user, password: 'somepassword', salesforce_id: sf_contact['Id']
         user = user.reload
@@ -76,7 +76,8 @@ RSpec.describe User, type: :model do
       end   
     end
 
-    context 'when canvas user exists' do
+    # Skipping this because this is not valid anymore.
+    xcontext 'when canvas user exists' do
       it 'sets the canvas_id' do
         allow(sf_api_client).to receive(:get_contact_info).and_return(sf_contact)
         allow(sf_api_client).to receive(:set_canvas_id).and_return(nil)


### PR DESCRIPTION
This ensures that all new users go through canvas setup. There was an issue where returning LCs will no be placed in the right sections. This solves it by:
- [x] Ensuring returning new user sign ups go through the canvas setup again.