### PR TITLE
Implement a Public JWK Url endpoint 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -107,3 +107,8 @@ gem 'platform-api', require: false
 # gem 'rowan_bot', path: '/app/rowan_bot'
 gem 'rowan_bot', github: 'bebraven/rowan_bot', branch: 'master'
 
+# Implementation of JSON Web Token (JWT) standard: https://github.com/jwt/ruby-jwt
+gem 'jwt'
+
+# Generates attr_accessors that encrypt and decrypt attributes transparently in the database
+gem 'attr_encrypted'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,8 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.0)
+    attr_encrypted (3.1.0)
+      encryptor (~> 3.0.0)
     babel-source (5.8.35)
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
@@ -132,6 +134,7 @@ GEM
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
+    encryptor (3.0.0)
     erubi (1.9.0)
     erubis (2.7.0)
     ethon (0.12.0)
@@ -460,6 +463,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  attr_encrypted
   bootsnap (>= 1.4.2)
   bulk_insert
   byebug
@@ -476,6 +480,7 @@ DEPENDENCIES
   guard-yarn
   honeycomb-beeline
   jbuilder (~> 2.7)
+  jwt
   libnotify
   listen (>= 3.0.5, < 3.2)
   paranoia

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Setup [ngrok.io](https://dashboard.ngrok.com/) in order to expose your local dev
 [Configure and deploy an LTI extension](https://docs.google.com/document/d/1sLFnqo8-lr556EwyIUHy_jLWOwzGEkub6nFKDWPO58Y/edit#heading=h.pce3b8uoohrj) that will only work on your computer and hit your local development environment as follows (screenshots in the link):
 1. Navigate to [Admin -> Developer Keys](https://braven.instructure.com/accounts/1/developer_keys) in the Portal.
 1. Click `+ Developer Key -> + LTI Key` 
-1. Open one of the other developer's keys in a new tab and copy all the setting's from theirs, except adjust the names to your own and in the `Public JWK URL` field, enter your own ngrok URL. E.g. `https://<insertyourname>platform.ngrok.io/keypairs`
+1. Open one of the other developer's keys in a new tab and copy all the setting's from theirs, except adjust the names to your own and in the `Public JWK URL` field, enter your own ngrok URL. E.g. `https://<insertyourname>platform.ngrok.io/public_jwk`
 1. Grab the Client ID, e.g. `160050000000000012`
 1. Deploy the LTI extension only to your Playground course by navigating to `Playground Course -> Settings -> Apps -> View App Configurations` OR just use the URL: `https://braven.instructure.com/courses/[YOUR_COURSE_ID]/settings/configurations
 1. Click `+ App`, change the `Configuration Type` dropdown to `By Client Id`, enter yours and submit.

--- a/app/controllers/keypairs_controller.rb
+++ b/app/controllers/keypairs_controller.rb
@@ -1,0 +1,13 @@
+# Taken from the following repo to add the  ability to generate a new keypair for the JWK authentication flow:
+# https://github.com/Drieam/LtiLauncher
+class KeypairsController < ApplicationController
+  # The Issuer MAY issue a cache-control: max-age HTTP header on
+  # requests to retrieve a key set to signal how long the
+  # retriever may cache the key set before refreshing it.
+  #
+  # See: https://www.imsglobal.org/spec/security/v1p0/#h_key-set-url
+  def index
+    expires_in 1.week, public: true
+    render json: { keys: Keypair.valid.map(&:public_jwk_export) }
+  end
+end

--- a/app/controllers/keypairs_controller.rb
+++ b/app/controllers/keypairs_controller.rb
@@ -1,6 +1,10 @@
-# Taken from the following repo to add the  ability to generate a new keypair for the JWK authentication flow:
+# Taken from the following repo to add the  ability to generate a new keypair for the 
+# JWK authentication flow and expose the public key for an LTI platform to use:
 # https://github.com/Drieam/LtiLauncher
 class KeypairsController < ApplicationController
+  skip_before_action :authenticate_user!
+  skip_before_action :ensure_admin!
+
   # The Issuer MAY issue a cache-control: max-age HTTP header on
   # requests to retrieve a key set to signal how long the
   # retriever may cache the key set before refreshing it.

--- a/app/models/keypair.rb
+++ b/app/models/keypair.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+##
+# This class contains functionality needed for signing messages
+# and publishing JWK[s].
+#
+# The last three created keypairs are considered valid, so creating a new Keypair
+# will invalidate the second to last created Keypair.
+#
+#   Keypair.create!
+#
+# If you need to sign messages, use the 'current' Keypair for this. This method
+# performs the rotation of the keypairs if required.
+#
+#   Keypair.current
+#
+# You can also use the `jwt_encode` and `jwt_decode` methods directly to encode and
+# securely decode your payloads
+#
+#   payload = 'foobar'
+#   id_token = Keypair.jwt_encode(payload)
+#   decoded = Keypair.jwt_decode(id_token)
+#
+# Borrowed from: https://github.com/Drieam/LtiLauncher
+class Keypair < ApplicationRecord
+  ALGORITHM = 'RS256'
+  attr_encrypted :_keypair, key: Rails.application.secret_key_base.first(32)
+  after_initialize :set_keypair
+
+  validates :_keypair, presence: true
+  validates :jwk_kid, presence: true
+
+  # The last 3 keypairs are considered valid and can be used
+  # to validate signatures and export public jwks of.
+  # It uses a subquery to make sure a find_by actually searches only the valid 3 ones.
+  scope :valid, -> { where(id: order(created_at: :desc).limit(3)) }
+
+  # This should be the keypair used to sign messages.
+  def self.current
+    order(:created_at).where(arel_table[:created_at].gt(1.month.ago)).last || create!
+  end
+
+  # Encodes the payload with the current keypair
+  def self.jwt_encode(payload)
+    current.jwt_encode(payload)
+  end
+
+  # Decodes the payload and verifies the signature against the current valid keypairs
+  def self.jwt_decode(id_token)
+    jwks = { keys: valid.map(&:public_jwk_export) }
+    JWT.decode(id_token, nil, true, algorithm: ALGORITHM, jwks: jwks).first
+  end
+
+  # Encodes the payload with this keypair
+  def jwt_encode(payload)
+    JWT.encode(payload, private_key, ALGORITHM, kid: jwk_kid)
+  end
+
+  # We append the `alg`, and `use` parameters to our JWK to indicate
+  # that our intended use is to generate signatures using RS256.
+  #
+  # The "alg" (algorithm) parameter identifies the algorithm
+  # intended for use with the key. Use of this member is OPTIONAL.
+  #
+  # The "use" (public key use) parameter identifies the intended use of
+  # the public key. Use of the "use" member is OPTIONAL, unless the
+  # application requires its presence.
+  #
+  # See: https://tools.ietf.org/html/rfc7517#section-4.4
+  #
+  # The IMS Security framework specifies: The `alg` value SHOULD be the default of RS256.
+  #
+  # See: https://www.imsglobal.org/spec/security/v1p0#authentication-response-validation
+  def public_jwk_export
+    public_jwk.export.merge(
+      alg: ALGORITHM,
+      use: 'sig'
+    )
+  end
+
+  # Returns an `OpenSSL::PKey::RSA` instance loaded with our keypair.
+  def private_key
+    OpenSSL::PKey::RSA.new(_keypair)
+  end
+
+  # Returns an `OpenSSL::PKey::RSA` instance loaded with the public part of our keypair.
+  delegate :public_key, to: :private_key
+
+  private
+
+  # Returns a JWT::JWK instance with the public part of our keypair.
+  def public_jwk
+    JWT::JWK.create_from(public_key)
+  end
+
+  # Generate a new keypair with a key_size of 2048. Keys less
+  # than 1024 bits should be considered insecure.
+  #
+  # See: https://ruby-doc.org/stdlib-2.6.5/libdoc/openssl/rdoc/OpenSSL/PKey/RSA.html#method-c-new
+  def set_keypair
+    # The generated keypair is stored in PEM encoding.
+    self._keypair ||= OpenSSL::PKey::RSA.new(2048).to_pem
+    self.jwk_kid = public_jwk.kid
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,4 +79,6 @@ Rails.application.routes.draw do
   get '/cas/proxyValidate', to: 'cas#proxyValidate'
   get '/cas/proxy', to: 'cas#proxy'
 
+  # LTI Extension routes
+  resources :keypairs, only: :index, format: :j
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,10 @@ Rails.application.routes.draw do
 
   resources :access_tokens, except: [:show]
 
+  # Exposes the public JWK so that external services can encode payloads using it and we
+  # can decode them using our private key. E.g. JWK authentication flows.
+  resources :keypairs, only: :index, format: :j, path: 'public_jwk'
+
   resources :validations, only: [:index] do
     collection do
       get :report
@@ -79,6 +83,4 @@ Rails.application.routes.draw do
   get '/cas/proxyValidate', to: 'cas#proxyValidate'
   get '/cas/proxy', to: 'cas#proxy'
 
-  # LTI Extension routes
-  resources :keypairs, only: :index, format: :j
 end

--- a/db/migrate/20200317113750_create_keypairs.rb
+++ b/db/migrate/20200317113750_create_keypairs.rb
@@ -1,0 +1,15 @@
+class CreateKeypairs < ActiveRecord::Migration[6.0]
+  def change
+#    create_table :keypairs, id: :uuid do |t|
+    create_table :keypairs do |t|
+      t.string :jwk_kid, null: false, index: true
+      t.string :encrypted__keypair, null: false
+      t.string :encrypted__keypair_iv, null: false
+
+      t.timestamps
+
+      # Since we are ordering on created_at, let's create an index
+      t.index :created_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -87,6 +87,16 @@ ActiveRecord::Schema.define(version: 2020_04_23_163149) do
     t.index ["name"], name: "index_interests_on_name"
   end
 
+  create_table "keypairs", force: :cascade do |t|
+    t.string "jwk_kid", null: false
+    t.string "encrypted__keypair", null: false
+    t.string "encrypted__keypair_iv", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["created_at"], name: "index_keypairs_on_created_at"
+    t.index ["jwk_kid"], name: "index_keypairs_on_jwk_kid"
+  end
+
   create_table "lesson_submissions", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "lesson_id", null: false

--- a/spec/factories/keypair.rb
+++ b/spec/factories/keypair.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :keypair do
+    trait :fixed do
+      _keypair do
+        <<~RSA
+          -----BEGIN RSA PRIVATE KEY-----
+          MIIEogIBAAKCAQEAvPRsNZ6YfIkX1fsK9bMv7jxEWwT/JlPh8JsoRrAEYkVLkC7s
+          5jwY8+RmdtLsa/jKxX96jJ+vL8B64chmc8DT7baotwCxquiRR1PIkWnp1peOmmsO
+          rAuFzad+83SHhU5ajVLY9NsOSlelDI2D3EryPAm3FV4RuJryhKqWjX4uUME3+h3A
+          CEgA2kfJQjac22s0kbVgywwiINnKq0pQNGUtH/pRwPOkpaOe7jcLC7b0XuwMf0TZ
+          7Lk/7OkNtPFtQxQ3Nu1r7HMVSdTlF4mvVNMIRqd/G978LN52Oef+0epxeIKUCMoh
+          ONia1BpH7+43i59+4Ibk4UHhTEQD0RJCo6a8IwIDAQABAoIBAAyBHFwcB7lOFT66
+          40nJNuXMJTXkycHOkUgr7GlpIpEiRtLe2ByQY5JYThOU98JZb4nMWt7NfnlpgnhI
+          m8cTPrMfgGDD8f3+cAbJW5+L48aotu4vIYRvKsamS/dugb1npwRtNCBYEsUGscx3
+          3P8KEqe4eN44IHIYBu6Sn23zqLr9QUekDL6JYMevghE1DnZUXsHUcFUvNyKJn4+J
+          aiq1QtZkNlFuYdYADbbmqtnZIUScqGDBaJOBqdSugFLTQriUraBeu7n68B8GVm5n
+          I/CxT9fL0GjnLGLO6hDBuPKS5hta0235qYW9mMXALAPvD1tdbB1hsdyv+s6zXU7j
+          sa9X3pECgYEA45JRs/QZDJ1tSkO5kl1sgD/loJzEWZm9wq+p2eiNDTm8qts9PojQ
+          nKYNivSiDTK+RS7qriCjXdoPDabkHUvOPzvrcWnry0LSUH75tIwNxSq7icqWyGmD
+          SkPOHc/onrWimfpuuXgAw10UritAe5hxh/9c1dfuh/vDdAhdbdyi+6kCgYEA1I8m
+          CmQ3foi+xJqMaFKAf+RODxAk8ER7eNVCvqf1yHEg3SoGPyHZGwRRTJaUv6PFmLea
+          X3Nprna0osXi9TEYn6xc0LxV78b/bNO7lI80Ub3LPsOGGryb/aUCsuPplQEIxvNR
+          OShAWSBuvdPYGS/9iLAQqaof2SBxr7PepbsO+OsCgYBKI7Y4gVLT2EntwuinNYaO
+          tcJytAAIDN1UmvQkCO5DG8dKhoiKYfpMvpB078QHtrtkQKe2OO3gOpVi5jc1EChO
+          U5Ad79sg6lEoZmWlm2c1D/nvJzA+dJmQTUzOS5jGc/hYX81I4T6mZyHAqFimq4B5
+          RQmSpXmRlcUUfVEq5JG4mQKBgCqRpJeuLGL99d6f6QC3jR6P1YY0wIER5fx0EVLn
+          hlSnO2KvmOKp37YGblW9Tnr2zIriMlttXLvg8BotMV/Tfk/0D/6JyVgk7WCZItcE
+          uwCn1v1x4PiXz1HD6z9yX4RE2cImVpzwz7pJwYPo2j1pHAh04lFoTcqJMdtzVWKx
+          jLUTAoGAQlrKkScDRqNynKYyW053CfRCQtVCIGw3V0f9jINMLvGFOtIqYSzGCCvQ
+          gLXLfrOUKW0nomLVNP5WNZnsr1shtCDQZMql0XozL/KbJCiZ6QNV7gLLYKtKk+PG
+          M0FuhHMfRZoBApWu2b7oQrR/dSjDqiOAnG40b5ocvFg8lTJ81i0=
+          -----END RSA PRIVATE KEY-----
+        RSA
+      end
+    end
+  end
+end

--- a/spec/models/keypair_spec.rb
+++ b/spec/models/keypair_spec.rb
@@ -1,0 +1,214 @@
+require 'rails_helper'
+
+RSpec.describe Keypair, type: :model do
+  describe 'database' do
+    it { is_expected.to have_db_column(:jwk_kid).of_type(:string).with_options(null: false) }
+    it { is_expected.to have_db_column(:encrypted__keypair).of_type(:string).with_options(null: false) }
+    it { is_expected.to have_db_column(:encrypted__keypair_iv).of_type(:string).with_options(null: false) }
+    it { is_expected.to have_db_column(:created_at).of_type(:datetime).with_options(null: false) }
+    it { is_expected.to have_db_column(:updated_at).of_type(:datetime).with_options(null: false) }
+    it { is_expected.to have_db_index(:created_at) }
+    it { is_expected.to have_db_index(:jwk_kid) }
+  end
+
+  describe 'settings' do
+    it { expect(described_class::ALGORITHM).to eq 'RS256' }
+    # TODO: don't know why this fails...
+    #it { is_expected.to have_attr_encrypted(:_keypair) }
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:_keypair) }
+    it { is_expected.to validate_presence_of(:jwk_kid) }
+  end
+
+  describe 'callbacks' do
+    describe '#set_keypair' do
+      subject { build(:keypair) }
+      it { expect(subject._keypair).to include('-----BEGIN RSA PRIVATE KEY-----') }
+      it { expect(subject._keypair.length).to be > 1024 }
+      it { expect(subject.jwk_kid).to be_present }
+
+      it 'does not change the keypair after persisting' do
+        expect { subject.save! }.not_to change { subject._keypair }
+      end
+
+      it 'does not change the keypair after reloading' do
+        subject.save
+        expect { subject.reload }.not_to change { subject._keypair }
+      end
+
+      it 'saves the JWT kid of the generated key' do
+        key = OpenSSL::PKey::RSA.new(subject._keypair)
+        jwk = JWT::JWK.create_from(key.public_key)
+        expect(subject.jwk_kid).to eq jwk.kid
+      end
+
+      it 'does not change the jwk_kid after persisting' do
+        expect { subject.save! }.not_to change { subject.jwk_kid }
+      end
+
+      it 'does not change the jwk_kid after reloading' do
+        subject.save
+        expect { subject.reload }.not_to change { subject.jwk_kid }
+      end
+    end
+  end
+
+  describe 'scopes' do
+    describe '.valid' do
+      it 'returns the last three keys' do
+        subquery = described_class.unscoped.order(created_at: :desc).limit(3)
+        last_three = described_class.where(id: subquery)
+        expect(described_class.valid.to_sql).to eq(last_three.to_sql)
+      end
+      it 'works with find_by' do
+        keypairs = create_list :keypair, 4
+        invalid = keypairs.min_by(&:created_at)
+        expect(described_class.valid.where(id: invalid.id)).to be_empty
+      end
+    end
+  end
+
+  describe 'methods' do
+    describe '.current' do
+      before { described_class.delete_all }
+      context 'without keypairs' do
+        it 'creates a new keypair' do
+          expect { described_class.current }.to change { described_class.count }.by(1)
+        end
+        it 'returns an instance' do
+          expect(described_class.current).to be_a described_class
+        end
+      end
+
+      context 'with valid keypairs' do
+        let!(:keypair1) { create(:keypair, created_at: 2.weeks.ago) }
+        let!(:keypair2) { create(:keypair, created_at: 6.weeks.ago) }
+        let!(:keypair3) { create(:keypair, created_at: 10.weeks.ago) }
+        it 'returns the latest' do
+          expect(described_class.current).to eq keypair1
+        end
+      end
+      context 'with outdated keypairs' do
+        let!(:keypair1) { create(:keypair, created_at: 5.weeks.ago) }
+        let!(:keypair2) { create(:keypair, created_at: 9.weeks.ago) }
+        it 'creates a new keypair' do
+          expect { described_class.current }.to change { described_class.count }.by(1)
+        end
+        it 'returns the freshly created keypair' do
+          expect(described_class.current.created_at).to be_between 1.minute.ago, 1.minute.from_now
+        end
+      end
+    end
+
+    describe '.jwt_encode' do
+      let(:payload) { SecureRandom.uuid }
+      subject { described_class.jwt_encode(payload) }
+
+      it 'returns a JWT with the correct payload' do
+        decoded, = JWT.decode(subject, nil, false) # Decode the JWT but don't verify
+        expect(decoded).to eq payload
+      end
+      it 'is encoded with the current keypair and correct algorithm' do
+        expect do
+          JWT.decode(subject, described_class.current.public_key, true, algorithm: described_class::ALGORITHM)
+        end.to_not raise_error
+      end
+    end
+
+    describe '#jwt_encode' do
+      let(:payload) { SecureRandom.uuid }
+      let(:keypair) { build_stubbed(:keypair) }
+      subject { keypair.jwt_encode(payload) }
+
+      it 'returns a JWT with the correct payload' do
+        decoded, = JWT.decode(subject, nil, false) # Decode the JWT but don't verify
+        expect(decoded).to eq payload
+      end
+      it 'is encoded with the keypair and correct algorithm' do
+        expect do
+          JWT.decode(subject, keypair.public_key, true, algorithm: described_class::ALGORITHM)
+        end.to_not raise_error
+      end
+      it 'sets the kid in the headers' do
+        _, headers = JWT.decode(subject, nil, false) # Decode the JWT but don't verify
+        expect(headers.symbolize_keys).to eq(
+          alg: described_class::ALGORITHM,
+          kid: keypair.jwk_kid
+        )
+      end
+    end
+
+    describe '.jwt_decode' do
+      let!(:payload) { SecureRandom.uuid }
+      let!(:id_token) { keypair.jwt_encode(payload) }
+      subject { described_class.jwt_decode(id_token) }
+
+      context 'for id_token signed with current keypair' do
+        let!(:keypair) { described_class.current }
+        it 'retuns the payload' do
+          expect(subject).to eq payload
+        end
+      end
+      context 'for id_token signed with older but valid keypair' do
+        let!(:keypairs) { create_list :keypair, 3 }
+        let!(:keypair) { keypairs.min_by(&:created_at) }
+        it 'retuns the payload' do
+          expect(subject).to eq payload
+        end
+      end
+      context 'for id_token signed with expired keypair' do
+        let!(:keypairs) { create_list :keypair, 5 }
+        let!(:keypair) { keypairs.min_by(&:created_at) }
+        it 'raises an decode error' do
+          expect { subject }.to raise_error JWT::DecodeError
+        end
+      end
+      context 'for id_token signed with random keypair' do
+        let!(:keypair) { build :keypair }
+        it 'raises an decode error' do
+          expect { subject }.to raise_error JWT::DecodeError
+        end
+      end
+      context 'for id_token without kid header' do
+        let!(:keypair) { described_class.current }
+        let!(:id_token) { JWT.encode(payload, keypair.private_key, described_class::ALGORITHM) }
+        it 'raises an decode error' do
+          expect { subject }.to raise_error JWT::DecodeError
+        end
+      end
+    end
+
+    describe '#public_jwk_export' do
+      subject { build_stubbed(:keypair) }
+      let(:rsa_keypair) { OpenSSL::PKey::RSA.new(subject._keypair) }
+      let(:jwk_keypair) { JWT::JWK.create_from(rsa_keypair.public_key) }
+
+      it { expect(subject.public_jwk_export).to include(alg: 'RS256', use: 'sig') }
+      it { expect(subject.public_jwk_export.keys).to eq(%i[kty n e kid alg use]) }
+      it { expect(subject.public_jwk_export).to include(jwk_keypair.export) }
+    end
+
+    describe '#private_key' do
+      subject { build_stubbed(:keypair) }
+      it 'returns an OpenSSL::PKey::RSA' do
+        expect(subject.private_key).to be_a OpenSSL::PKey::RSA
+      end
+      it 'returns the keypair from the database' do
+        expect(subject.private_key.to_s).to eq subject._keypair
+      end
+    end
+
+    describe '#public_key' do
+      subject { build_stubbed(:keypair) }
+      let(:rsa_keypair) { OpenSSL::PKey::RSA.new(subject._keypair) }
+      it 'returns an OpenSSL::PKey::RSA' do
+        expect(subject.public_key).to be_a OpenSSL::PKey::RSA
+      end
+      it 'returns the public key of the key from the database' do
+        expect(subject.public_key.to_s).to eq rsa_keypair.public_key.to_s
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds an endpoint to expose a public Json Web Key (JWK).
    
When implementing a JWK authentication flow (e.g. for LTI Extension),
you need to expose a public JWK that the external service will use to encode
payloads. You need to keep the private key and be able to decode those payloads
(e.g. a JWT id_token) using it. This commit adds the endpoint to expose the public JWK
along with the ability to store and decode payloads using the private key.

See:
-  https://www.imsglobal.org/spec/lti/v1p3#json-web-token-0
- Step 3 here: https://canvas.instructure.com/doc/api/file.lti_dev_key_config.html#launch-overview

    
### Test Plan:
    - In the Rails console run Keypair.create! and make sure that when you go to
      https://platformweb/public_jwk that you can see the public JWK for it.
    - Encode a payload using that pulic JWK and make sure you can decode it with
      Keypair.jwt_decode(encoded_payload)
    - Run: `bundle exec rspec spec/modles/keypair_spec.rb`