### PR TITLE
Change config defaults from Rails v5.2 to v6.0

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -8,8 +8,13 @@ Bundler.require(*Rails.groups)
 
 module Platform
   class Application < Rails::Application
+
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.2
+    config.load_defaults 6.0
+
+    # Determines whether forgery protection is added on ActionController:Base. This is false by default to
+    # be backwards compatible with v5.2 and below who may have removed it from ApplicationController
+    config.action_controller.default_protect_from_forgery = true
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers


### PR DESCRIPTION
The most notable difference in this change is that Rails 6.0 auto-loader
defaults to zeitwerk and that protect_from_forgery was moved to ActionController::Base.

See:
- https://app.asana.com/0/1179330853755533/1167505329038728
- https://app.asana.com/0/1179330853755533/1159485936661651

### Test Plan:
- bundle exec rspec
- Sign in, sign up, and Content Editor publish still work (main three features that are live so far.
- Rebuild in production mode and make sure the above works.
- If anything else breaks, let's just fix it. We're early enough in this codebase that we should do this now and just deal with any side effects asap.