### PR TITLE
Implement the LTI Launch flow.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,10 +11,6 @@ CANVAS_URL=http://canvasweb:3000/
 #CANVAS_TOKEN=BEW8ldtbMypKZiCs8EmW2eQXfOoBpfOEwNJXwyvfIKZIpMgQzBfYUugc4V20oFgt
 # Booster API token
 CANVAS_TOKEN=XAlbyObifoe76wJECtpLDGEvIVViPVklRnhAkWvUFIm8957NSS5eonRn5oYGqb0y
-# This value comes from here: https://canvas.instructure.com/doc/api/file.lti_dev_key_config.html#launch-overview
-CANVAS_LTI_URL=https://canvas.instructure.com
-# Configured as the Redirect URI in the Developer Key on Canvas
-CANVAS_LTI_REDIRECT_URL=https://platformweb/lti/launch
 DATABASE_HOST=platformdb
 DATABASE_USERNAME=user
 DATABASE_PASSWORD=password

--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,10 @@ CANVAS_URL=http://canvasweb:3000/
 #CANVAS_TOKEN=BEW8ldtbMypKZiCs8EmW2eQXfOoBpfOEwNJXwyvfIKZIpMgQzBfYUugc4V20oFgt
 # Booster API token
 CANVAS_TOKEN=XAlbyObifoe76wJECtpLDGEvIVViPVklRnhAkWvUFIm8957NSS5eonRn5oYGqb0y
+# This value comes from here: https://canvas.instructure.com/doc/api/file.lti_dev_key_config.html#launch-overview
+CANVAS_LTI_URL=https://canvas.instructure.com
+# Configured as the Redirect URI in the Developer Key on Canvas
+CANVAS_LTI_REDIRECT_URL=https://platformweb/lti/launch
 DATABASE_HOST=platformdb
 DATABASE_USERNAME=user
 DATABASE_PASSWORD=password

--- a/app/controllers/lti_launch_controller.rb
+++ b/app/controllers/lti_launch_controller.rb
@@ -47,7 +47,7 @@ class LtiLaunchController < ApplicationController
     idt = LtiIdToken.parse_and_verify(params[:id_token])
 
     @lti_launch = LtiLaunch.current(params[:state])
-    @lti_launch.id_token_payload = idt.payload
+    @lti_launch.id_token_payload = idt.payload.to_json
     @lti_launch.save!
 
     # Step 4 in the flow, show the target resource now that we've saved the id_token payload that contains

--- a/app/controllers/lti_launch_controller.rb
+++ b/app/controllers/lti_launch_controller.rb
@@ -1,0 +1,54 @@
+require 'lti_id_token'
+
+# Implement the LTI 1.3 Launch Flow. Here is a nice summary of that flow by Canvas, our LMS:
+# https://canvas.instructure.com/doc/api/file.lti_dev_key_config.html#launch-overview
+#
+# Summary of flow:
+# Step 1: Login Initiation - Canvas calls into here letting us know a launch is starting
+# Step 2: Authentication Response - We initiate an handshake to authenticate the launch establish a trust in the launch
+# Step 3: LTI Launch - The launch is initated with meta-data about the context and the final target resource to launch
+# Step 4: Resource Display - We display the target resource
+class LtiLaunchController < ApplicationController
+  skip_before_action :authenticate_user!
+  skip_before_action :ensure_admin!
+  skip_before_action :verify_authenticity_token
+
+  # Non-standard controller without normal CRUD methods. Disable the convenience module.
+  def dry_crud_enabled?() false end
+
+  # POST /lti/login
+  #
+  # This is the OIDC url Canvas is calling in Step 1 above.
+  def login
+    raise ActionController::BadRequest.new(), "Unexpected iss parameter: #{params[:iss]}" if params[:iss] != ENV['CANVAS_LTI_URL']
+
+    # Force load the session by writing something to it. Reading from it isn't enough to initialize it and get a session_id
+    session[:init] = true
+
+    @lti_launch = LtiLaunch.create!(params.except(:iss, :canvas_region).permit(:client_id, :login_hint, :target_link_uri, :lti_message_hint)
+                                         .merge(:state => session[:session_id], :nonce => SecureRandom.hex(10)))
+
+    # Step 2 in the flow, do the handshake
+    redirect_to "#{ENV['CANVAS_LTI_URL']}/api/lti/authorize_redirect?#{@lti_launch.auth_params.to_query}"
+  end
+
+
+  # POST /lti/launch
+  #
+  # This is the endpoint configured as the Redirect URI in the Canvas Developer Key. It's Step 3 in the launch flow.
+  def launch
+    params.require([:id_token, :state])
+
+    # This also verifies the request is coming from Canvas using the public JWK 
+    # as described in Step 3 here: https://canvas.instructure.com/doc/api/file.lti_dev_key_config.html
+    idt = LtiIdToken.parse_and_verify(params[:id_token])
+
+    @lti_launch = LtiLaunch.current(params[:state])
+    @lti_launch.id_token_payload = idt.payload
+    @lti_launch.save!
+
+    # Step 4 in the flow, show the target resource now that we've saved the id_token payload that contains
+    # user identifiers, course contextual data, custom data, etc.
+    redirect_to @lti_launch.target_link_uri
+  end
+end

--- a/app/controllers/lti_launch_controller.rb
+++ b/app/controllers/lti_launch_controller.rb
@@ -16,11 +16,14 @@ class LtiLaunchController < ApplicationController
   # Non-standard controller without normal CRUD methods. Disable the convenience module.
   def dry_crud_enabled?() false end
 
+  LTI_ISS=Rails.application.secrets.lti_oidc_base_uri
+  LTI_AUTH_RESPONSE_URL="#{Rails.application.secrets.lti_oidc_base_uri}/api/lti/authorize_redirect".freeze
+
   # POST /lti/login
   #
   # This is the OIDC url Canvas is calling in Step 1 above.
   def login
-    raise ActionController::BadRequest.new(), "Unexpected iss parameter: #{params[:iss]}" if params[:iss] != ENV['CANVAS_LTI_URL']
+    raise ActionController::BadRequest.new(), "Unexpected iss parameter: #{params[:iss]}" if params[:iss] != LTI_ISS
 
     # Force load the session by writing something to it. Reading from it isn't enough to initialize it and get a session_id
     session[:init] = true
@@ -29,7 +32,7 @@ class LtiLaunchController < ApplicationController
                                          .merge(:state => session[:session_id], :nonce => SecureRandom.hex(10)))
 
     # Step 2 in the flow, do the handshake
-    redirect_to "#{ENV['CANVAS_LTI_URL']}/api/lti/authorize_redirect?#{@lti_launch.auth_params.to_query}"
+    redirect_to "#{LTI_AUTH_RESPONSE_URL}?#{@lti_launch.auth_params.to_query}"
   end
 
 

--- a/app/models/lti_launch.rb
+++ b/app/models/lti_launch.rb
@@ -3,7 +3,9 @@
 # https://canvas.instructure.com/doc/api/file.lti_dev_key_config.html#launch-overview
 class LtiLaunch < ApplicationRecord
 
-  LTI_LAUNCH_REDIRECT_URI=ENV['CANVAS_LTI_REDIRECT_URL'].freeze
+  # This is the Redirect URI that must be configured in the Developer Key for the LTI
+  # and must match EXACTLY.
+  LTI_LAUNCH_REDIRECT_URI="https://#{Rails.application.secrets.application_host}/lti/launch".freeze
 
   # Usage:
   #
@@ -23,7 +25,7 @@ class LtiLaunch < ApplicationRecord
       :response_mode => 'form_post',         # OIDC response is always a form post
       :prompt => 'none',                     # Don't prompt user on redirect
       :client_id => client_id,
-      :redirect_uri => LTI_LAUNCH_REDIRECT_URI,  # URL to return to after login. Must match EXACTLY what is configured in the Developer Key
+      :redirect_uri => LTI_LAUNCH_REDIRECT_URI,  # URL to return to after login
       :state => state,                       # State to identify browser session
       :nonce => nonce,                       # Prevent replay attacks 
       :login_hint =>  login_hint,            # Login hint to identify platform (aka Canvas) session

--- a/app/models/lti_launch.rb
+++ b/app/models/lti_launch.rb
@@ -1,0 +1,34 @@
+# Stores info about an LTI launch so we can access that stuff in future calls
+# in the context of that launch. See this for details about the LTI launch flow
+# https://canvas.instructure.com/doc/api/file.lti_dev_key_config.html#launch-overview
+class LtiLaunch < ApplicationRecord
+
+  LTI_LAUNCH_REDIRECT_URI=ENV['CANVAS_LTI_REDIRECT_URL'].freeze
+
+  # Usage:
+  #
+  # LtiLaunch.current(session[:session_id])
+  def self.current(session_id)
+    LtiLaunch.find_by!(state: session_id)
+  end
+
+  # Returns the parameters needed in Step 2 of the LTI Launch flow in order
+  # to do the handshake with the LTI platform (aka Canvas) and "login" / authenitcate
+  # an LTI launch / session. See: 
+  # http://www.imsglobal.org/spec/security/v1p0/#step-2-authentication-request
+  def auth_params
+    {
+      :scope => 'openid',                    # OIDC Scope
+      :response_type => 'id_token',          # OIDC response is always an id token
+      :response_mode => 'form_post',         # OIDC response is always a form post
+      :prompt => 'none',                     # Don't prompt user on redirect
+      :client_id => client_id,
+      :redirect_uri => LTI_LAUNCH_REDIRECT_URI,  # URL to return to after login. Must match EXACTLY what is configured in the Developer Key
+      :state => state,                       # State to identify browser session
+      :nonce => nonce,                       # Prevent replay attacks 
+      :login_hint =>  login_hint,            # Login hint to identify platform (aka Canvas) session
+      :lti_message_hint => lti_message_hint  # Used by platform (aka Canvas) to store / identify context on their end. Opaque to us.
+    }
+  end
+end
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,4 +83,8 @@ Rails.application.routes.draw do
   get '/cas/proxyValidate', to: 'cas#proxyValidate'
   get '/cas/proxy', to: 'cas#proxy'
 
+  # LTI Extension Routes
+  post '/lti/login', to: 'lti_launch#login'
+  post '/lti/launch', to: 'lti_launch#launch'
+
 end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -10,6 +10,8 @@ development:
   devise_pepper: <%= ENV['DEVISE_PEPPER'] %>
   honeycomb_dataset: <%= ENV['HONEYCOMB_DATASET'] %>
   honeycomb_write_key: <%= ENV['HONEYCOMB_WRITE_KEY'] %>
+  # This value comes from here: https://canvas.instructure.com/doc/api/file.lti_dev_key_config.html#launch-overview
+  lti_oidc_base_uri: <%= ENV.fetch('LTI_OIDC_BASE_URI') { 'https://canvas.instructure.com' } %>
   salesforce_consumer_key: <%= ENV['SALESFORCE_PLATFORM_CONSUMER_KEY'] %>
   salesforce_consumer_secret: <%= ENV['SALESFORCE_PLATFORM_CONSUMER_SECRET'] %>
   salesforce_username: <%= ENV['SALESFORCE_PLATFORM_USERNAME'] %>
@@ -33,6 +35,7 @@ test:
   devise_pepper: <%= ENV['DEVISE_PEPPER'] %>
   honeycomb_dataset: <%= ENV['HONEYCOMB_DATASET'] %>
   honeycomb_write_key: <%= ENV['HONEYCOMB_WRITE_KEY'] %>
+  lti_oidc_base_uri: <%= ENV.fetch('LTI_OIDC_BASE_URI') { 'https://example.lms.com' } %>
   salesforce_consumer_key: <%= ENV['SALESFORCE_PLATFORM_CONSUMER_KEY'] %>
   salesforce_consumer_secret: <%= ENV['SALESFORCE_PLATFORM_CONSUMER_SECRET'] %>
   salesforce_username: <%= ENV['SALESFORCE_PLATFORM_USERNAME'] %>
@@ -56,6 +59,7 @@ staging:
   devise_pepper: <%= ENV['DEVISE_PEPPER'] %>
   honeycomb_dataset: <%= ENV['HONEYCOMB_DATASET'] %>
   honeycomb_write_key: <%= ENV['HONEYCOMB_WRITE_KEY'] %>
+  lti_oidc_base_uri: <%= ENV.fetch('LTI_OIDC_BASE_URI') { 'https://canvas.instructure.com' } %>
   salesforce_consumer_key: <%= ENV['SALESFORCE_PLATFORM_CONSUMER_KEY'] %>
   salesforce_consumer_secret: <%= ENV['SALESFORCE_PLATFORM_CONSUMER_SECRET'] %>
   salesforce_username: <%= ENV['SALESFORCE_PLATFORM_USERNAME'] %>
@@ -79,6 +83,7 @@ production:
   devise_pepper: <%= ENV['DEVISE_PEPPER'] %>
   honeycomb_dataset: <%= ENV['HONEYCOMB_DATASET'] %>
   honeycomb_write_key: <%= ENV['HONEYCOMB_WRITE_KEY'] %>
+  lti_oidc_base_uri: <%= ENV.fetch('LTI_OIDC_BASE_URI') { 'https://canvas.instructure.com' } %>
   salesforce_consumer_key: <%= ENV['SALESFORCE_PLATFORM_CONSUMER_KEY'] %>
   salesforce_consumer_secret: <%= ENV['SALESFORCE_PLATFORM_CONSUMER_SECRET'] %>
   salesforce_username: <%= ENV['SALESFORCE_PLATFORM_USERNAME'] %>

--- a/db/migrate/20200625120447_create_lti_launches.rb
+++ b/db/migrate/20200625120447_create_lti_launches.rb
@@ -1,0 +1,18 @@
+# Stores info about an LTI launch so we can access that stuff in future calls
+# in the context of that launch
+class CreateLtiLaunches < ActiveRecord::Migration[6.0]
+  def change
+    create_table :lti_launches do |t|
+      t.string :client_id, null: false
+      t.string :login_hint, null: false
+      t.text :lti_message_hint                 # This is an optional param in a launch, but Canvas does send it
+      t.string :target_link_uri, null: false
+      t.string :nonce, null: false
+      t.string :state, null: false
+      t.index :state                           # This is what we use to identify the session and look up the launch info
+      t.text :id_token_payload
+      
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_23_163149) do
+ActiveRecord::Schema.define(version: 2020_06_25_120447) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -150,6 +150,19 @@ ActiveRecord::Schema.define(version: 2020_04_23_163149) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["day_of_week", "time_of_day", "program_id"], name: "index_logistics_on_day_of_week_and_time_of_day_and_program_id", unique: true
+  end
+
+  create_table "lti_launches", force: :cascade do |t|
+    t.string "client_id", null: false
+    t.string "login_hint", null: false
+    t.text "lti_message_hint"
+    t.string "target_link_uri", null: false
+    t.string "nonce", null: false
+    t.string "state", null: false
+    t.text "id_token_payload"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["state"], name: "index_lti_launches_on_state"
   end
 
   create_table "majors", force: :cascade do |t|

--- a/lib/lti_id_token.rb
+++ b/lib/lti_id_token.rb
@@ -21,7 +21,7 @@ class LtiIdToken
   # Takes a signed JWT id_token (base64encoded) and parses the contents out while
   # verifying the signature so that we know it was actually sent by the LTI platform
   def self.parse_and_verify(signed_jwt_id_token)
-    payload, header = JWT.decode(signed_jwt_id_token, nil, true, { algorithms: ['RS256'], jwks: jwks } )
+    payload, header = JWT.decode(signed_jwt_id_token, nil, true, { algorithms: ['RS256'], jwks: public_jwks } )
     LtiIdToken.new(payload, header)
   rescue => e
     Rails.logger.error("{\"Error\":\"#{e.message}\"}")
@@ -31,11 +31,7 @@ class LtiIdToken
 
   private
 
-  def self.jwks
-    @jwks ||= fetch_jwks # These are rotated monthly for Canvas and the server restarts once a day. Safe to cache.
-  end
-
-  def self.fetch_jwks
+  def self.public_jwks
     response = RestClient.get(PUBLIC_JWKS_URL)
     JSON.parse(response.body, symbolize_names: true)
   end

--- a/lib/lti_id_token.rb
+++ b/lib/lti_id_token.rb
@@ -11,7 +11,7 @@ class LtiIdToken
 
   # The URL of the Public JWK used to sign payloads sent from Canvas so that we can
   # verify it was actually Canvas sending the payload and not an attacker.
-  PUBLIC_JWKS_URL = "#{ENV['CANVAS_LTI_URL']}/api/lti/security/jwks".freeze
+  PUBLIC_JWKS_URL = "#{Rails.application.secrets.lti_oidc_base_uri}/api/lti/security/jwks".freeze
 
   def initialize(payload, header)
     @header = header

--- a/lib/lti_id_token.rb
+++ b/lib/lti_id_token.rb
@@ -1,0 +1,43 @@
+require 'rest-client'
+
+# Helps parse and valid an LTI extension id_token sent in the authentication response
+# of an LTI Launch.
+# See: 
+# - https://medium.com/@darutk/understanding-id-token-5f83f50fa02e
+# - https://canvas.instructure.com/doc/api/file.lti_dev_key_config.html#launch-overview
+# - http://www.imsglobal.org/spec/security/v1p0/#authentication-response-validation
+class LtiIdToken
+  attr_reader :header, :payload
+
+  # The URL of the Public JWK used to sign payloads sent from Canvas so that we can
+  # verify it was actually Canvas sending the payload and not an attacker.
+  PUBLIC_JWKS_URL = "#{ENV['CANVAS_LTI_URL']}/api/lti/security/jwks".freeze
+
+  def initialize(payload, header)
+    @header = header
+    @payload = payload
+  end
+
+  # Takes a signed JWT id_token (base64encoded) and parses the contents out while
+  # verifying the signature so that we know it was actually sent by the LTI platform
+  def self.parse_and_verify(signed_jwt_id_token)
+    payload, header = JWT.decode(signed_jwt_id_token, nil, true, { algorithms: ['RS256'], jwks: jwks } )
+    LtiIdToken.new(payload, header)
+  rescue => e
+    Rails.logger.error("{\"Error\":\"#{e.message}\"}")
+    Rails.logger.error(e.response.body)
+    raise
+  end
+
+  private
+
+  def self.jwks
+    @jwks ||= fetch_jwks # These are rotated monthly for Canvas and the server restarts once a day. Safe to cache.
+  end
+
+  def self.fetch_jwks
+    response = RestClient.get(PUBLIC_JWKS_URL)
+    JSON.parse(response.body, symbolize_names: true)
+  end
+end
+

--- a/spec/api_helper.rb
+++ b/spec/api_helper.rb
@@ -6,7 +6,12 @@ class JsonStrategy
   delegate :association, to: :@strategy
 
   def result(evaluation)
-    @strategy.result(evaluation).to_json
+    result = @strategy.result(evaluation)
+    evaluation.notify(:before_json, result)
+
+    result.to_json.tap do |json|
+      evaluation.notify(:after_json, json)
+    end
   end
 end
 

--- a/spec/controllers/lti_launch_controller_spec.rb
+++ b/spec/controllers/lti_launch_controller_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe LtiLaunchController, type: :controller do
+
+  let(:valid_session) { { :session_id => SecureRandom.hex(10) } }
+  let(:session_id) { valid_session[:session_id] }
+
+  describe 'POST #login' do
+    let(:lti_launch_params) { build(:lti_launch_login_params) }
+
+    before(:each) do
+      post :login, params: lti_launch_params, session: valid_session
+    end
+
+    it 'creates an LtiLaunch' do
+      lti_launch = LtiLaunch.current(session_id)
+      expect(lti_launch).not_to be_nil
+    end 
+
+    it 'sends the LtiLaunch auth_params to the platform redirect_uri' do
+      lti_launch = LtiLaunch.current(session_id)
+      expect(response).to redirect_to("#{LtiLaunchController::LTI_AUTH_RESPONSE_URL}?#{lti_launch.auth_params.to_query}")
+    end 
+  end
+
+  describe 'POST #launch' do
+    let!(:target_link_uri) { 'https://target/link' }
+    let!(:lti_launch) { create(:lti_launch_model, target_link_uri: target_link_uri, state: session_id) }
+    let!(:id_token_payload) { FactoryBot.json(:lti_link_launch_request) }
+    let!(:id_token) { Keypair.jwt_encode(JSON.parse(id_token_payload, symbolize_names: true)) }
+    let!(:lti_launch_params) { { :id_token => id_token, :state => session_id } }
+
+    before(:each) do
+      public_jwks = JSON.parse({ keys: [ Keypair.current.public_jwk_export ] }.to_json, symbolize_names: true)
+      allow(LtiIdToken).to receive(:jwks).and_return(public_jwks)
+      post :launch, params: lti_launch_params, session: valid_session
+    end
+
+    it 'saves the id_token payload in the LtiLaunch' do
+      lti_launch = LtiLaunch.current(session_id)
+      expect(JSON.parse(lti_launch.id_token_payload)).to eq(JSON.parse(id_token_payload))
+    end 
+
+    it 'redirects to the target_link_uri' do
+      expect(response).to redirect_to(target_link_uri)
+    end 
+  end
+
+end
+

--- a/spec/controllers/lti_launch_controller_spec.rb
+++ b/spec/controllers/lti_launch_controller_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe LtiLaunchController, type: :controller do
     let!(:lti_launch_params) { { :id_token => id_token, :state => session_id } }
 
     before(:each) do
-      public_jwks = JSON.parse({ keys: [ Keypair.current.public_jwk_export ] }.to_json, symbolize_names: true)
-      allow(LtiIdToken).to receive(:jwks).and_return(public_jwks)
+      public_jwks = { keys: [ Keypair.current.public_jwk_export ] }.to_json
+      stub_request(:get, LtiIdToken::PUBLIC_JWKS_URL).to_return(body: public_jwks)
       post :launch, params: lti_launch_params, session: valid_session
     end
 

--- a/spec/factories/lti_launch.rb
+++ b/spec/factories/lti_launch.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :lti_launch do
+    client_id { '160040000000055555' }
+    login_hint { '914c015dc6637dfb1518ef9c9e02a5918940f67d' }
+    target_link_uri { 'https://some/target/link/uri' }
+    nonce { SecureRandom.hex(10) }
+    state { '0c69ef6a12af720cc180487271040450' }
+    lti_message_hint { 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ2ZXJpZmllciI6ImQ0OTZjNGMxMGQzMTc5ZGRhNTI4Yjg2MjM3YTY4ZDAyNjEzMDEzYmFkMDUwMGZhZDM5ZDY1N2E0MzZmZDMyMWJjYTBjMWJmYzVmNTY3OWI5ZTQyMDY0NTRhNzQ4ZjAyODM0NmRmNTVhY2VlM2FiOTFjZDA0ZmQwNzU2NGFlZDJkIiwiY2FudmFzX2RvbWFpbiI6ImJyYXZlbi5pbnN0cnVjdHVyZS5jb20iLCJjb250ZXh0X3R5cGUiOiJDb3Vyc2UiLCJjb250ZXh0X2lkIjoxNjAwNTAwMDAwMDAwMDAwNDAsImV4cCI6MTU5MzA4NzYyNX0.mUvaDSdCo-dh-PDCHhL6iDs5Py2hzPU1_bJcKQyWveM' }
+  
+    factory :lti_launch_resource do
+      id_token_payload { FactoryBot.json(:lti_link_launch_request) }
+    end 
+  end
+end

--- a/spec/factories/lti_launch.rb
+++ b/spec/factories/lti_launch.rb
@@ -3,12 +3,22 @@ FactoryBot.define do
     client_id { '160040000000055555' }
     login_hint { '914c015dc6637dfb1518ef9c9e02a5918940f67d' }
     target_link_uri { 'https://some/target/link/uri' }
-    nonce { SecureRandom.hex(10) }
-    state { '0c69ef6a12af720cc180487271040450' }
     lti_message_hint { 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ2ZXJpZmllciI6ImQ0OTZjNGMxMGQzMTc5ZGRhNTI4Yjg2MjM3YTY4ZDAyNjEzMDEzYmFkMDUwMGZhZDM5ZDY1N2E0MzZmZDMyMWJjYTBjMWJmYzVmNTY3OWI5ZTQyMDY0NTRhNzQ4ZjAyODM0NmRmNTVhY2VlM2FiOTFjZDA0ZmQwNzU2NGFlZDJkIiwiY2FudmFzX2RvbWFpbiI6ImJyYXZlbi5pbnN0cnVjdHVyZS5jb20iLCJjb250ZXh0X3R5cGUiOiJDb3Vyc2UiLCJjb250ZXh0X2lkIjoxNjAwNTAwMDAwMDAwMDAwNDAsImV4cCI6MTU5MzA4NzYyNX0.mUvaDSdCo-dh-PDCHhL6iDs5Py2hzPU1_bJcKQyWveM' }
+   
+    factory :lti_launch_login_params, class: Hash do
+      skip_create # This isn't stored in the DB.
+      iss { Rails.application.secrets.lti_oidc_base_uri }
+      canvas_region { "us-west-2" }
+      initialize_with { attributes.stringify_keys }
+    end
+
+    factory :lti_launch_model do
+      nonce { SecureRandom.hex(10) }
+      state { SecureRandom.hex(10) }
   
-    factory :lti_launch_resource do
-      id_token_payload { FactoryBot.json(:lti_link_launch_request) }
-    end 
+      factory :lti_launch_resource do
+        id_token_payload { FactoryBot.json(:lti_link_launch_request) }
+      end 
+    end
   end
 end

--- a/spec/factories/lti_link_launch_request.rb
+++ b/spec/factories/lti_link_launch_request.rb
@@ -1,0 +1,119 @@
+FactoryBot.define do
+
+# Represents an LTI Resource link launch request message. E.g. after adding
+# a lesson to a Canvas module, when the student goes to open that lesson
+# this is the message to launch it.
+# See: https://www.imsglobal.org/spec/lti/v1p3#resource-link-launch-request-message
+#
+# IMPORTANT: this is meant to be built with FactoryBot.json(:lti_link_launch_request)
+# and if you don't then it will be missing the json keys that are URLs
+
+  factory :lti_link_launch_request, class: Hash do
+    skip_create # This isn't stored in the DB.
+    iss { 'https://some.lti.platform' }
+    aud { '160040000000000055' }
+    azp { '160040000000000055' }
+    exp { '1593205904' }
+    iat { '1593205904' }
+    nonce { 'f16e8f1b581ec93fadb1' }
+    sub { 'lti_user_id' }
+    locale { 'en' }
+
+    # These are not valid attributes so they have to be added manually to the hash. Only works when this
+    # factory is built using: FactoryBot.json(...) 
+    before(:json) do |request_msg| 
+      request_msg.merge!({
+        'https://purl.imsglobal.org/spec/lti/claim/message_type' => 'LtiResourceLinkRequest',
+        'https://purl.imsglobal.org/spec/lti/claim/version' => '1.3.0',
+        'https://purl.imsglobal.org/spec/lti/claim/deployment_id' => '59:id_of_lti_deployment',
+        'https://purl.imsglobal.org/spec/lti/claim/target_link_uri' => 'https://platformweb/some/target/uri/to/launch',
+        'https://purl.imsglobal.org/spec/lti/claim/resource_link' => {
+          'id' => 'id_of_the_resource_being_launched',
+          'description' => nil,
+           'title' => nil
+        },
+        'https://purl.imsglobal.org/spec/lti/claim/roles' => [
+          'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Administrator',
+          'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Instructor',
+          'http://purl.imsglobal.org/vocab/lis/v2/membership#ContentDeveloper',
+          'http://purl.imsglobal.org/vocab/lis/v2/system/person#User'
+        ],
+        'https://purl.imsglobal.org/spec/lti/claim/context' => {
+          'id' =>'id_of_the_course_context',
+          'label' => 'CourseLabel',
+          'title' => 'CourseName',
+          'type' => [ 'http://purl.imsglobal.org/vocab/lis/v2/course#CourseOffering' ]
+        },
+        'https://purl.imsglobal.org/spec/lti/claim/tool_platform' => {
+          'guid' => 'id_of_instance_of_platform:canvas-lms',
+          'name' => 'Braven - Cloud',
+          'version' => 'cloud',
+          'product_family_code' => 'canvas'
+        },
+        'https://purl.imsglobal.org/spec/lti/claim/launch_presentation' => {
+          'document_target' => 'iframe',
+          'height' => nil,
+          'width' => nil,
+          'return_url' => 'https://some/path/on/the/platform/to/go/back/to/when/done',
+          'locale' => 'en',
+        },
+        'https://purl.imsglobal.org/spec/lti/claim/custom' => {
+          'role' => 'DesignerEnrollment,Account Admin',
+          'title' =>'CourseTitle',
+          'lti_url' => '$LtiLink.custom.url',
+          'user_id' => 55555,
+          'timezone' => 'America/New_York',
+          'course_id' => 55,
+          'module_id' => 555,
+          'account_id' => 5,
+          'context_id' => 'id_of_the_resource_being_launched',
+          'user_email' => 'example@exampl.org',
+          'course_name' => 'CourseName',
+          'section_ids' => '55',
+          'account_name' => 'Manually-Created Courses',
+          'browser_info' => 'iframe',
+          'assignment_id' => '$Canvas.assignment.id',
+          'attachment_id' => '$Canvas.file.media.id',
+          'submission_id' => '$com.instructure.Submission.id',
+          'user_fullname' => 'Brian Nairb',
+          'module_item_id' => 555,
+          'submission_url' => 'api/lti/assignments/{assignment_id}/submissions/{submission_id}',
+          'user_last_name' => 'Nairb',
+          'user_first_name' => 'Brian',
+          'assignment_title' => '$Canvas.assignment.title',
+          'attachment_title' => '$Canvas.file.media.title',
+          'course_source_id' => nil,
+          'assignment_due_at' => '$Canvas.assignment.dueAt.iso8601',
+          'assignment_lti_id' => '$com.instructure.Assignment.lti.id',
+          'assignment_points' => '$Canvas.assignment.pointsPossible',
+          'context_source_id' => nil,
+          'assignment_lock_date' => '$Canvas.assignment.lockAt.iso8601',
+          'assignment_unlock_date' => '$Canvas.assignment.unlockAt.iso8601',
+          'submission_history_url' => 'api/lti/assignments/{assignment_id}/submissions/{submission_id}/history'
+        },
+        'errors' => { 'errors' => {} },
+
+        # Note: I think these are Canvas specific service URLs available in this launch context. See:
+        # https://www.imsglobal.org/spec/lti/v1p3#services-exposed-as-additional-claims
+        'https://purl.imsglobal.org/spec/lti-ags/claim/endpoint' => {
+          'scope' => [
+            'https://purl.imsglobal.org/spec/lti-ags/scope/lineitem',
+            'https://purl.imsglobal.org/spec/lti-ags/scope/lineitem.readonly',
+            'https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly',
+            'https://purl.imsglobal.org/spec/lti-ags/scope/score'
+          ],
+          'lineitems' => 'https://platformdomain/api/lti/courses/55/line_items'
+        },
+        'https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice' => {
+          'context_memberships_url' => 'https://braven.instructure.com/api/lti/courses/40/names_and_roles',
+          'service_versions' => [ '2.0' ]
+        }
+
+      })
+    end
+
+    initialize_with { attributes.stringify_keys }
+  end
+
+end
+

--- a/spec/factories/lti_link_launch_request.rb
+++ b/spec/factories/lti_link_launch_request.rb
@@ -13,8 +13,8 @@ FactoryBot.define do
     iss { 'https://some.lti.platform' }
     aud { '160040000000000055' }
     azp { '160040000000000055' }
-    exp { '1593205904' }
-    iat { '1593205904' }
+    exp { Time.now.to_i + 50000 }
+    iat { Time.now.to_i }
     nonce { 'f16e8f1b581ec93fadb1' }
     sub { 'lti_user_id' }
     locale { 'en' }

--- a/spec/models/lti_launch_spec.rb
+++ b/spec/models/lti_launch_spec.rb
@@ -1,6 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe LtiLaunch, type: :model do
+
+  before(:all) do
+    REDIRECT_URI = "https://#{Rails.application.secrets.application_host}/lti/launch"
+  end
+
   describe 'database' do
     it { is_expected.to have_db_column(:client_id).of_type(:string).with_options(null: false) }
     it { is_expected.to have_db_column(:login_hint).of_type(:string).with_options(null: false) }
@@ -15,18 +20,50 @@ RSpec.describe LtiLaunch, type: :model do
   end
 
   describe 'settings' do
-    it { expect(described_class::LTI_LAUNCH_REDIRECT_URI).to eq "https://#{Rails.application.secrets.application_host}/lti/launch" }
+    it { expect(described_class::LTI_LAUNCH_REDIRECT_URI).to eq REDIRECT_URI }
   end
 
   describe 'methods' do
-    describe '.current' do
-      context 'without keypairs' do
-        let(:lti_launch) { build(:lti_launch_resource) }
+    subject(:lti_launch) { create(:lti_launch_resource) }
+    let(:state_param) { lti_launch.state }
 
-        it 'does something' do
-          puts "### #{lti_launch.id_token_payload}"
+    describe '.current' do
+      context 'when exists' do
+        it 'is found' do
+          session_id = state_param
+          expect(LtiLaunch.current(session_id)).to eq(lti_launch) 
         end
       end
     end
+
+    describe '#auth_params' do
+      let(:auth_params) { lti_launch.auth_params }
+
+      it 'sets the client_id' do
+        expect(auth_params[:client_id]).to eq(lti_launch.client_id)
+      end 
+
+      it 'sets the redirect_uri' do
+        expect(auth_params[:redirect_uri]).to eq(REDIRECT_URI)
+      end 
+
+      it 'sets the state' do
+        expect(auth_params[:state]).to eq(lti_launch.state)
+      end 
+
+      it 'sets the nonce' do
+        expect(auth_params[:nonce]).to eq(lti_launch.nonce)
+      end 
+
+      it 'sets the login_hint' do
+        expect(auth_params[:login_hint]).to eq(lti_launch.login_hint)
+      end 
+
+      it 'sets the lti_message_hint' do
+        expect(auth_params[:lti_message_hint]).to eq(lti_launch.lti_message_hint)
+      end 
+
+    end
+
   end
 end

--- a/spec/models/lti_launch_spec.rb
+++ b/spec/models/lti_launch_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe LtiLaunch, type: :model do
+  describe 'database' do
+    it { is_expected.to have_db_column(:client_id).of_type(:string).with_options(null: false) }
+    it { is_expected.to have_db_column(:login_hint).of_type(:string).with_options(null: false) }
+    it { is_expected.to have_db_column(:lti_message_hint).of_type(:text) }
+    it { is_expected.to have_db_column(:target_link_uri).of_type(:string).with_options(null: false) }
+    it { is_expected.to have_db_column(:nonce).of_type(:string).with_options(null: false) }
+    it { is_expected.to have_db_column(:state).of_type(:string).with_options(null: false) }
+    it { is_expected.to have_db_column(:id_token_payload).of_type(:text) }
+    it { is_expected.to have_db_column(:created_at).of_type(:datetime).with_options(null: false) }
+    it { is_expected.to have_db_column(:updated_at).of_type(:datetime).with_options(null: false) }
+    it { is_expected.to have_db_index(:state) }
+  end
+
+  describe 'settings' do
+    it { expect(described_class::LTI_LAUNCH_REDIRECT_URI).to eq "https://#{Rails.application.secrets.application_host}/lti/launch" }
+  end
+
+  describe 'methods' do
+    describe '.current' do
+      context 'without keypairs' do
+        let(:lti_launch) { build(:lti_launch_resource) }
+
+        it 'does something' do
+          puts "### #{lti_launch.id_token_payload}"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This implements the flow described here:
https://canvas.instructure.com/doc/api/file.lti_dev_key_config.html#launch-overview

### Test Plan:
- Configure your Developer Key with the Redirect URI that exactly matches
  `https://ENV['APPLICATION_HOST']/lti/launch`
- Do an LTI Launch, e.g. if your LTI has a Link Selection placement,
  go to a Module, click the + to add something, select External Tool,
  then click on the name of your LTI. It should start the launch flow and
  successfully load the Target URI that you configured in the Developer Key
  for the Link Selection placement. E.g. https://platformweb/whatever/endpoint/i/implement in the image below
![image](https://user-images.githubusercontent.com/5596986/86922386-88efdf00-c0fa-11ea-8da8-501612097aa4.png)
- In future requests, you can access the metadata about the current LTI Launch (e.g. user_id, etc) using: `LtiLaunch.current(session[:session_id])`
- The following specs should pass:
    `bundle exec rspec spec/models/lti_launch_spec.rb`
    `bundle exec rspec spec/controllers/lti_launch_controller_spec.rb `