### PR TITLE
Add the honeycomb stuff back

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,3 +37,6 @@ SPEC_HOST=platformweb
 SPEC_PORT=49883
 # Allow pages to be iframed from another domain (wildcards permitted).
 CSP_FRAME_ANCESTORS_HOST="braven.instructure.com"
+# These have to be set if you want to run rspec.
+HONEYCOMB_DATASET=development
+HONEYCOMB_WRITE_KEY=

--- a/lib/lti_id_token.rb
+++ b/lib/lti_id_token.rb
@@ -35,8 +35,11 @@ class LtiIdToken
   end
 
   def self.public_jwks
-    response = RestClient.get(PUBLIC_JWKS_URL)
-    JSON.parse(response.body, symbolize_names: true)
+    Honeycomb.start_span(name: 'LtiIdToken.public_jwks') do |span|
+      span.add_field('url', PUBLIC_JWKS_URL)
+      response = RestClient.get(PUBLIC_JWKS_URL)
+      JSON.parse(response.body, symbolize_names: true)
+    end
   end
   private_class_method :public_jwks
 


### PR DESCRIPTION
It only crashes rspec if you don't have env vars set up.

Be sure to add honeycomb settings to your `.env`:

```sh
HONEYCOMB_DATASET=development
HONEYCOMB_WRITE_KEY=
```

Get the key from here: https://ui.honeycomb.io/teams/braven