### PR TITLE
Allow unsafe inline styles

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -10,7 +10,7 @@ Rails.application.config.content_security_policy do |policy|
   policy.img_src     :self, :https, :data
   policy.object_src  :none
   policy.script_src  :self, :https
-  policy.style_src   :self, :https
+  policy.style_src   :self, :https, :unsafe_inline
   policy.frame_ancestors :self
 
   # Customizable through .env

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -10,6 +10,7 @@ Rails.application.config.content_security_policy do |policy|
   policy.img_src     :self, :https, :data
   policy.object_src  :none
   policy.script_src  :self, :https
+  # Unsafe-inline styles are bad. Remove this once we've migrated modules to Rise 360.
   policy.style_src   :self, :https, :unsafe_inline
   policy.frame_ancestors :self
 


### PR DESCRIPTION
This PR allows inline styles like `<div style="color: red;">` on platform. This is insecure.

More info: https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#rule-4-css-escape-and-strictly-validate-before-inserting-untrusted-data-into-html-style-property-values

We're allowing this because we have inline styles in module content, and fixing all of those would be a significant amount of work. Moving forward, we should:

1. Not add additional inline styles to any page.
2. Not allow inline styles in the stripped-down assignments-only content editor.
3. Once we move content to Rise 360 and no longer have old modules, remove this rule from the CSP config.

Task: https://app.asana.com/0/1156506513832825/1184172178554017/f