### PR TITLE
Make honeycomb not error out if the write key is blank

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,7 +94,7 @@ gem 'rubycas-server-core', github: 'bebraven/rubycas-server-core', branch: 'plat
 gem 'rubycas-server-activerecord'
 
 # Honeycomb
-gem 'honeycomb-beeline', require: false
+gem 'honeycomb-beeline'
 
 # Allows us to write rake tasks that can programatticaly run Heroku commands
 # using their API. E.g. create a task to restart a dyno so it can be run

--- a/config/initializers/honeycomb.rb
+++ b/config/initializers/honeycomb.rb
@@ -1,23 +1,14 @@
-if Rails.application.secrets.honeycomb_write_key && Rails.application.secrets.honeycomb_dataset
-  if Gem.loaded_specs.has_key?('honeycomb-beeline')
-    require "honeycomb-beeline"
-
-    Rails.logger.info "Honeycomb Beeline detected. Initalizing setup."
-    Honeycomb.configure do |config|
-      config.write_key = Rails.application.secrets.honeycomb_write_key
-      config.dataset = Rails.application.secrets.honeycomb_dataset
-      config.notification_events = %w[
-        sql.active_record
-        render_template.action_view
-        render_partial.action_view
-        render_collection.action_view
-        process_action.action_controller
-        send_file.action_controller
-        send_data.action_controller
-        deliver.action_mailer
-      ].freeze
-    end
-  else
-    Rails.logger.warn "Honeycomb Beeline is not install. Skipping initialization."
-  end
+Honeycomb.configure do |config|
+  config.write_key = Rails.application.secrets.honeycomb_write_key
+  config.dataset = Rails.application.secrets.honeycomb_dataset
+  config.notification_events = %w[
+    sql.active_record
+    render_template.action_view
+    render_partial.action_view
+    render_collection.action_view
+    process_action.action_controller
+    send_file.action_controller
+    send_data.action_controller
+    deliver.action_mailer
+  ].freeze
 end


### PR DESCRIPTION
When the Rails.application.secrets.honeycomb_write_key was empty,
the honeycomb gem wasn't even loaded and so calls to Honeycomb.start_span
would fail. This lets you leave it blank in dev and we always want to
load it in prod anyway.