### PR TITLE
Fix OpenSSL::Cipher::CipherError with the public JWKs.

### DIFF
--- a/app/models/keypair.rb
+++ b/app/models/keypair.rb
@@ -47,7 +47,8 @@
 # Borrowed from: https://github.com/Drieam/LtiLauncher
 class Keypair < ApplicationRecord
   ALGORITHM = 'RS256'
-  attr_encrypted :_keypair, key: Rails.application.secret_key_base.first(32)
+  # Note: we directly use the ENV var b/c Rails.application.secret_key_base gets regenerated in dev and breaks our ability to decrypt existing keys.
+  attr_encrypted :_keypair, key: ENV['SECRET_KEY_BASE'].first(32) 
   after_initialize :set_keypair
 
   validates :_keypair, presence: true


### PR DESCRIPTION
Had to go deep into the Rails code to figure this out. Basically,
in production this wouldn't be a problem, but in Dev and Test, Rails
dynamically generates the secret_key_base and stores it in
`tmp/development_secret.txt` -- when switching around branches and rebuilding
the container, this probably get blown away or somehow regenerated which causes
all previously stored keypairs to fail to decrypt b/c the key changed. We
already put a dev `SECRET_KEY_BASE` in the `.env.example`, so after truncating
the keypairs table in dev this shouldn't be a problem anymore.

Test Plan
- bundle exec rspec
- Run `Keypair.create!` in the console and hit http://platformweb/public_jwk
  Rebuild the container and remove `tmp/development_secret.txt`. The public_jwk
  URL should still return the public JWK for the keypair you created.