### PR TITLE
Adds a reverse proxy to the AWS S3 hosted files for the LTI lessons.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -116,6 +116,4 @@ gem 'attr_encrypted'
 gem 'aws-sdk-s3'
 gem 'rubyzip'
 
-gem 'rack-cors'
-
 gem 'rails_same_site_cookie'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -291,8 +291,6 @@ GEM
     public_suffix (4.0.5)
     puma (3.12.6)
     rack (2.2.3)
-    rack-cors (1.1.1)
-      rack (>= 2.0.0)
     rack-livereload (0.3.17)
       rack
     rack-proxy (0.6.5)
@@ -515,7 +513,6 @@ DEPENDENCIES
   pry-rescue
   pry-stack_explorer
   puma (~> 3.12)
-  rack-cors
   rack-livereload
   rails (~> 6.0.0)
   rails_same_site_cookie

--- a/app/models/lesson_content.rb
+++ b/app/models/lesson_content.rb
@@ -8,10 +8,7 @@ class LessonContent < ApplicationRecord
   has_one_attached :lesson_content_zipfile
 
   def launch_url
-    # TODO: in a future iteration we'll want to generate pre-signed URLs with expirations on
-    # them so that our content doesn't get leaked for anyone to access. Right now the bucket is public
-    # but we'll want to lock it down.
-    LessonContentPublisher.launch_url(lesson_content_zipfile.key)
+   "#{LtiLessonContentsProxy.proxy_url}#{LessonContentPublisher.launch_path(lesson_content_zipfile.key)}"
   end
    
   private

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,6 +2,8 @@ require_relative 'boot'
 
 require 'rails/all'
 
+require_relative '../lib/lti_lesson_contents_proxy'
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
@@ -16,13 +18,8 @@ module Platform
     # be backwards compatible with v5.2 and below who may have removed it from ApplicationController
     config.action_controller.default_protect_from_forgery = true
 
-    # Allows Rise 360 lesson running in AWS S3 to call into our LRS xAPI proxy
-    config.middleware.insert_before 0, Rack::Cors do
-      allow do
-        origins "https://#{Rails.application.secrets.aws_files_bucket}.s3.amazonaws.com"
-        resource '*', :headers => :any, :methods => [:get, :put,]
-      end
-    end
+    # Allows us to serve Rise360 static files hosted on AWS S3 through our server avoiding browser cross-origin issues.
+    config.middleware.use LtiLessonContentsProxy, backend: "https://#{Rails.application.secrets.aws_files_bucket}.s3.amazonaws.com"
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,6 @@
+# Needed to use the url_helpers outside of views and controller
+Rails.application.routes.default_url_options[:host] = Rails.application.secrets.application_host 
+
 Rails.application.routes.draw do
 
   resources :course_contents do
@@ -98,4 +101,7 @@ Rails.application.routes.draw do
 
   # Proxy xAPI messages to the LRS.
   match '/data/xAPI/*endpoint', to: 'lrs_xapi_proxy#xAPI', via: [:get, :put]
+
+  # There is a route similar to the commented out one below that doesn't show up here. See 'lib/lti_lesson_contents_proxy.rb' and 'config/application.rb'
+  # match '/lesson_contents_proxy/*endpoint', to: AWS_S3
 end

--- a/lib/lesson_content_publisher.rb
+++ b/lib/lesson_content_publisher.rb
@@ -8,9 +8,13 @@ class LessonContentPublisher
   # Publicly accessible URL for the lesson
   # The "filekey" is the "key" attribute of an ActiveStorage zipfile.
   # Aka the name of the zipfile on S3.
-  def self.launch_url(filekey, bucket = nil)
+  def self.launch_path(filekey, bucket = nil)
+    # TODO: in a future iteration we'll want to generate pre-signed URLs with expirations on
+    # them so that our content doesn't get leaked for anyone to access. Right now the bucket is public
+    # but we'll want to lock it down.
     bucket = AwsS3Bucket.new unless bucket
-    bucket.object(s3_object_key(filekey, INDEX_FILE)).public_url
+    aws_url = bucket.object(s3_object_key(filekey, INDEX_FILE)).public_url
+    URI(aws_url).request_uri
   end
 
   # Publishes an ActiveStorage zipfile (with a "key" attribute)
@@ -32,7 +36,7 @@ class LessonContentPublisher
         end
       end
 
-      launch_url(zipfile.key, bucket)
+      launch_path(zipfile.key, bucket)
   end
 
 

--- a/lib/lesson_content_publisher.rb
+++ b/lib/lesson_content_publisher.rb
@@ -5,7 +5,9 @@ class LessonContentPublisher
   S3_OBJECT_PREFIX = "lessons".freeze
   INDEX_FILE = "index.html".freeze
 
-  # Publicly accessible URL for the lesson
+  # The full request_uri, aka path (including query params) to be able to launch
+  # the lesson. 
+  #
   # The "filekey" is the "key" attribute of an ActiveStorage zipfile.
   # Aka the name of the zipfile on S3.
   def self.launch_path(filekey, bucket = nil)

--- a/lib/lti_lesson_contents_proxy.rb
+++ b/lib/lti_lesson_contents_proxy.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+require 'rack/proxy'
+
+# Implements a reverse proxy to our published LessonContent on AWS S3.
+# Needed to avoid security concerns with cross origin / AJAX / XHR browser issues.
+# More context: https://app.asana.com/0/1174274412967132/1186566037117865
+#
+# Hitting a path like:
+#
+#   https://platformweb/lesson_contents_proxy/the/path/on/aws/s3
+# 
+# will cause the request/response to be proxied to the configured AWS S3 bucket at
+#
+#   https://bucket.s3.amazonaws.com/the/path/on/aws/s3
+#
+class LtiLessonContentsProxy < Rack::Proxy
+
+  PROXIED_PATH='/lesson_contents_proxy'
+  PROXY_REGEX=/^#{Regexp.escape(PROXIED_PATH)}(\/.*)$/
+
+  # E.g. https://platformweb/lesson_contents_proxy
+  def self.proxy_url
+    # This is hard-coded to HTTPS b/c none of this stuff works over HTTP and in dev thats the default
+    # if we use a helper URL like: Rails.application.routes.url_helpers.root_url
+    @proxl_url ||= "https://#{Rails.application.secrets.application_host}#{PROXIED_PATH}"
+  end
+
+  def perform_request(env)
+    request = Rack::Request.new(env)
+    if request.path =~ PROXY_REGEX
+      env["HTTP_HOST"] = @backend.host # e.g. some-bucket.s3.amazonaws.com
+      env['PATH_INFO'] = $1            # The match in the regex above
+      super(env)
+    else
+      @app.call(env)
+    end
+  end
+
+end

--- a/lib/lti_lesson_contents_proxy.rb
+++ b/lib/lti_lesson_contents_proxy.rb
@@ -22,7 +22,7 @@ class LtiLessonContentsProxy < Rack::Proxy
   def self.proxy_url
     # This is hard-coded to HTTPS b/c none of this stuff works over HTTP and in dev thats the default
     # if we use a helper URL like: Rails.application.routes.url_helpers.root_url
-    @proxl_url ||= "https://#{Rails.application.secrets.application_host}#{PROXIED_PATH}"
+    @proxy_url ||= "https://#{Rails.application.secrets.application_host}#{PROXIED_PATH}"
   end
 
   def perform_request(env)

--- a/spec/lib/lesson_content_publisher_spec.rb
+++ b/spec/lib/lesson_content_publisher_spec.rb
@@ -22,13 +22,13 @@ RSpec.describe LessonContentPublisher do
     end
   end
 
-  describe '#launch_url' do
+  describe '#launch_path' do
     context 'when valid Rise360 zipfile' do
 
       it 'returns launch URL' do
         allow(LessonContentPublisher).to receive(:publish).and_return("https://S3-bucket-path/lessons/somekey/index.html")
-        expect(aws_object).to receive(:public_url)
-        LessonContentPublisher.launch_url(lesson_content.lesson_content_zipfile.key)
+        expect(aws_object).to receive(:public_url).and_return("https://S3-bucket-path/lessons/somekey/index.html")
+        expect(LessonContentPublisher.launch_path(lesson_content.lesson_content_zipfile.key)).to eq('/lessons/somekey/index.html')
       end
 
     end

--- a/spec/lib/lti_lesson_contents_proxy_spec.rb
+++ b/spec/lib/lti_lesson_contents_proxy_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe LtiLessonContentsProxy do
+  include Rack::Test::Methods # Allows us to use a dummy Rack::Request / Response framework
+
+  before(:all) do
+    @aws_bucket_url = "https://#{Rails.application.secrets.aws_files_bucket}.s3.amazonaws.com"
+  end
+
+  let(:dummy_host) { 'platform.host' }
+  let(:dummy_path) { '/some/path' }
+  let(:dummy_env) { { 'HTTP_HOST' => dummy_host, 'PATH_INFO' => dummy_path } }
+  let(:dummy_body) { 'Hello world!' }
+  let(:dummy_app) { proc{[200,dummy_env,[dummy_body]]} }
+  #let(:stack) { LrsXapiProxy.new(app) }
+  #let(:request) { Rack::MockRequest.new(stack) }
+
+  # This "app" is required by Rack::Test::Methods
+  def app
+   LtiLessonContentsProxy.new(dummy_app, :backend => @aws_bucket_url)
+  end
+
+  context 'non-proxied request' do
+
+    it 'ignores root path' do
+      get('/')
+      expect(WebMock).not_to have_requested(:any, @aws_bucket_url)
+      expect(last_request.get_header('HTTP_HOST')).to eq(Rack::Test::DEFAULT_HOST)
+    end
+
+    it 'ignores SSO path' do
+      get('/cas/login')
+      expect(WebMock).not_to have_requested(:any, @aws_bucket_url)
+      expect(last_request.get_header('HTTP_HOST')).to eq(Rack::Test::DEFAULT_HOST)
+    end
+
+  end
+
+  context 'proxied request' do
+    let(:fake_html) { '<html><head></head><body>Proxied Response</body></html>' }
+    let(:aws_request_uri) { '/lessons/ytec17h3ckbr92vcf7nklxmat4tc/index.html?' \
+                           'actor=%7B%22name%22%3A%22LESSON_CONTENTS_USERNAME_REPLACE%22%2C%20%22mbox%22%3A%5B%22mailto%3ALESSON_CONTENTS_PASSWORD_REPLACE%22%5D%7D'\
+                           '&endpoint=https%3A%2F%2Fplatformweb%2Fdata%2FxAPI' 
+                         }
+    let(:original_full_path) { "#{LtiLessonContentsProxy::PROXIED_PATH}#{aws_request_uri}" }
+    let(:proxied_request_url) { "#{@aws_bucket_url}#{aws_request_uri}" }
+
+    before(:each) do
+      stub_request(:get, proxied_request_url).to_return({:body => fake_html})
+      get(original_full_path)
+    end
+
+    it 'hits the AWS S3 endpoint' do
+      expect(WebMock).to have_requested(:get, proxied_request_url).once
+      expect(last_response.body).to eq(fake_html)
+    end
+
+    it 'sets the host header to AWS' do
+      expect(last_request.host).to eq(URI(@aws_bucket_url).host)
+    end
+
+  end
+end 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -109,3 +109,7 @@ end
 # Helps with formatting JSON using factories.
 require 'api_helper'
 
+# Patch HttpStreamingResponse to make rack-proxy compatible with webmocks
+# Note: we "load" here b/c it was already "required" before the Rack stuff loaded
+# so it seemed to be getting clobbered.
+load 'support/http_streaming_response_patch'

--- a/spec/support/http_streaming_response_patch.rb
+++ b/spec/support/http_streaming_response_patch.rb
@@ -1,0 +1,54 @@
+# Taken from: https://github.com/waterlink/rack-reverse-proxy/blob/master/spec/support/http_streaming_response_patch.rb
+#Copyright (c) 2009 Jon Swope
+#
+#Permission is hereby granted, free of charge, to any person obtaining
+#a copy of this software and associated documentation files (the
+#"Software"), to deal in the Software without restriction, including
+#without limitation the rights to use, copy, modify, merge, publish,
+#distribute, sublicense, and/or sell copies of the Software, and to
+#permit persons to whom the Software is furnished to do so, subject to
+#the following conditions:
+#
+#The above copyright notice and this permission notice shall be
+#included in all copies or substantial portions of the Software.
+#
+#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+#EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+#MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+#LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+#OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+#WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+##
+# Patch HttpStreamingResponse
+# in order to support webmocks and still use rack-proxy
+#
+# Inspired by @ehlertij commits on sportngin/rack-proxy:
+# 616574e452fa731f5427d2ff2aff6823fcf28bde
+# d8c377f7485997b229ced23c33cfef87d3fb8693
+# 75b446a26ceb519ddc28f38b33309e9a2799074c
+# 
+module Rack
+  class HttpStreamingResponse
+    def each(&block)
+      response.read_body(&block)
+    ensure
+      session.end_request_hacked unless mocking?
+    end
+
+    protected
+
+    def response
+      if mocking?
+        @response ||= session.request(@request)
+      else
+        super
+      end
+    end
+
+    def mocking?
+      defined?(WebMock) || defined?(FakeWeb)
+    end
+  end
+end 


### PR DESCRIPTION
Now we can give Canvas a URL to launch on our server for the Rise360
lesson content which is hosted on AWS S3 and our server will proxy the
request/response so that both Canvas and the browser think the files
live on our server which we can more easily control the trusting relationship
we've developed. We need this b/c the content tries to Ajax request xApi statements
to the LRS but since it's cross-origin things go awry. The above task has more 
context on the discussion: https://app.asana.com/0/1174274412967132/1186566037117865/f

Example:
https://platformweb/lesson_contents_proxy/lessons/ytec17h3ckbr92vcf7nklxmat4tc/index.html?actor=%7B%22name%22%3A%22LESSON_CONTENTS_USERNAME_REPLACE%22%2C%20%22mbox%22%3A%5B%22mailto%3ALESSON_CONTENTS_PASSWORD_REPLACE%22%5D%7D&endpoint=https%3A%2F%2Fplatformweb%2Fdata%2FxAPI

### Test Plan:
Load an existing or new Lesson and look at the network traffic. It should successfully send xApi statements to the LRS. Login to the LRS to verify. Note that in an incognito window you have to allow third party cookies for all this LTI stuff to work.