### PR TITLE
Move loader plugins from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,16 +62,16 @@
     "webpack": "4.43.0",
     "webpack-cli": "3",
     "webpack-merge": "^4.2.2",
-    "webpacker-react": "^1.0.0-beta.1"
+    "webpacker-react": "^1.0.0-beta.1",
+    "sass-loader": "^9.0.2",
+    "node-sass": "^4.14.1"
   },
   "devDependencies": {
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.15.1",
     "jest": "^26.0.1",
     "jest-enzyme": "^7.1.2",
-    "node-sass": "^4.14.1",
     "react-axe": "^3.3.0",
-    "sass-loader": "^9.0.2",
     "webpack-dev-server": "^3.11.0"
   },
   "scripts": {


### PR DESCRIPTION
This is causing the deployment on heroku to fail. It is not reproducible on local since the flow is different.