### PR TITLE
Add canvas user id when creating user at join

### DIFF
--- a/app/services/setup_portal_account.rb
+++ b/app/services/setup_portal_account.rb
@@ -16,7 +16,7 @@ class SetupPortalAccount
   def run
     find_or_create_portal_user!
     user = User.find_by!(salesforce_id: sf_contact_id)
-    join_user_id = find_or_create_join_user!(user).id if should_create_join_user?
+    join_user_id = find_or_create_join_user!(user, portal_user.id).id if should_create_join_user?
     sync_portal_enrollment!
     update_user_references!(user, salesforce_id: sf_contact_id,
                                   join_user_id: join_user_id)
@@ -25,7 +25,7 @@ class SetupPortalAccount
 
   private
 
-  attr_reader :sf_contact_id
+  attr_reader :sf_contact_id, :portal_user
 
   def sync_portal_enrollment!
     SyncPortalEnrollmentForAccount
@@ -45,8 +45,8 @@ class SetupPortalAccount
     user
   end
 
-  def find_or_create_join_user!(user)
-    UpdateJoinUsers.new.run([user]).first
+  def find_or_create_join_user!(user, portal_user_id)
+    UpdateJoinUsers.new.run([{ user: user, canvas_user_id: portal_user_id }]).first
   end
 
   def should_create_join_user?

--- a/app/services/update_join_users.rb
+++ b/app/services/update_join_users.rb
@@ -4,11 +4,13 @@ require 'join_api'
 
 # UpdateJoinUsers finds platform user who are not in join and create them
 class UpdateJoinUsers
-  def run(users)
-    users.map do |user|
+  def run(entries)
+    entries.map do |entry|
+      user = entry[:user]
       join_user = find_or_create_join_user!(email: user.email,
                                             first_name: user.first_name,
-                                            last_name: user.last_name)
+                                            last_name: user.last_name,
+                                            canvas_user_id: entry[:canvas_user_id])
       user.update!(join_user_id: join_user.id)
       join_user
     end
@@ -16,12 +18,12 @@ class UpdateJoinUsers
 
   private
 
-  def find_or_create_join_user!(email:, first_name:, last_name:)
+  def find_or_create_join_user!(email:, first_name:, last_name:, canvas_user_id:)
     join_user = join_api_client.find_user_by(email: email)
     return join_user unless join_user.nil?
 
     join_api_client.create_user(email: email, first_name: first_name,
-                                last_name: last_name)
+                                last_name: last_name, canvas_user_id: canvas_user_id)
   end
 
   def join_api_client

--- a/lib/join_api.rb
+++ b/lib/join_api.rb
@@ -23,8 +23,8 @@ class JoinAPI
     make_user_response(response.first)
   end
 
-  def create_user(email:, first_name:, last_name:)
-    data = { user: { email: email, first_name: first_name, last_name: last_name } }
+  def create_user(email:, first_name:, last_name:, canvas_user_id:)
+    data = { user: { email: email, first_name: first_name, last_name: last_name, canvas_user_id: canvas_user_id } }
     response = request(method: :post, path: 'users', body: data)
 
     make_user_response(response)

--- a/lib/tasks/maintenance/update_join_users.rake
+++ b/lib/tasks/maintenance/update_join_users.rake
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-namespace :maintenance do
-  desc 'Run the join user update'
-  task update_join_users: :environment do
-    users = User.where(join_user_id: nil)
-    UpdateJoinUsers.new.run(users)
-  end
-end

--- a/spec/lib/join_api_spec.rb
+++ b/spec/lib/join_api_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe JoinAPI do
       test_email = 'test@example.com'
       stub_request(:any, join_user_create_path).to_return(body: { email: test_email, id: 1 }.to_json)
 
-      join_api_client.create_user(email: test_email, first_name: 'first_name', last_name: 'last_name')
+      join_api_client.create_user(email: test_email, first_name: 'first_name', last_name: 'last_name', canvas_user_id: 'canvas_user_id')
 
       expect(WebMock).to have_requested(:post, join_user_create_path)
         .with(headers: { 'Authorization' => "Bearer #{Rails.application.secrets.join_api_token}" }).once
@@ -55,7 +55,7 @@ RSpec.describe JoinAPI do
       test_email = 'test@example.com'
       stub_request(:any, join_user_create_path).to_return(body: { email: test_email, id: 1 }.to_json)
 
-      response = join_api_client.create_user(email: test_email, first_name: 'first_name', last_name: 'last_name')
+      response = join_api_client.create_user(email: test_email, first_name: 'first_name', last_name: 'last_name', canvas_user_id: canvas_user_id)
 
       expect(response.email).to eql(test_email)
     end
@@ -63,7 +63,7 @@ RSpec.describe JoinAPI do
     it 'raises error when there is an error' do
       stub_request(:any, join_user_create_path).to_return(status: [500, 'Internal Server Error'])
 
-      expect { join_api_client.create_user(email: 'test@email.com', first_name: 'first_name', last_name: 'last_name') }.to raise_error RestClient::InternalServerError
+      expect { join_api_client.create_user(email: 'test@email.com', first_name: 'first_name', last_name: 'last_name', canvas_user_id: 'canvas_user_id') }.to raise_error RestClient::InternalServerError
     end
   end
 end

--- a/spec/lib/join_api_spec.rb
+++ b/spec/lib/join_api_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe JoinAPI do
       test_email = 'test@example.com'
       stub_request(:any, join_user_create_path).to_return(body: { email: test_email, id: 1 }.to_json)
 
-      response = join_api_client.create_user(email: test_email, first_name: 'first_name', last_name: 'last_name', canvas_user_id: canvas_user_id)
+      response = join_api_client.create_user(email: test_email, first_name: 'first_name', last_name: 'last_name', canvas_user_id: 'canvas_user_id')
 
       expect(response.email).to eql(test_email)
     end

--- a/spec/services/update_join_users_spec.rb
+++ b/spec/services/update_join_users_spec.rb
@@ -21,19 +21,19 @@ RSpec.describe UpdateJoinUsers do
     end
 
     it 'finds a user if the user already exist' do
-      UpdateJoinUsers.new.run([dummy_user])
+      UpdateJoinUsers.new.run([{ user: dummy_user, canvas_user_id: nil }])
 
       expect(join_api_client).to have_received(:find_user_by)
     end
 
     it 'create a new user if the user does not exist' do
-      UpdateJoinUsers.new.run([dummy_user])
+      UpdateJoinUsers.new.run([{ user: dummy_user, canvas_user_id: nil }])
 
       expect(join_api_client).to have_received(:create_user)
     end
 
     it 'updates join user id for the user' do
-      UpdateJoinUsers.new.run([dummy_user])
+      UpdateJoinUsers.new.run([{ user: dummy_user, canvas_user_id: nil }])
 
       expect(dummy_user).to have_received(:update!)
     end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
This adds canvas user to canvas user when creating join user on sign up

### Motivation and Context
Join users without canvas user id cause a weird error


### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask around. -->

- [x] My code follows the code style of this project.
- [x] I have added neccessary labels
- [x] My PR title follows the convention in the guide
- [x] I have assigned myself to the PR
- [x] I have requested reviews from team members
- [ ] I have created a task for reviewers on PM tool
- [ ] All new and existing tests passed.
