### PR TITLE
WIP: Check if a user exists with a 15 or 18 SF character ID 

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'salesforce_id_formatter'
+
 class Users::RegistrationsController < Devise::RegistrationsController
   layout 'accounts'
   before_action :configure_sign_up_params, only: [:create]
@@ -61,6 +63,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   def find_user_by_salesforce_id
+    # TODO: update to check if an account exists with a 15-char or 18-char
     User.find_by(salesforce_id: salesforce_id)
   end
 

--- a/lib/salesforce_id_formatter.rb
+++ b/lib/salesforce_id_formatter.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+# Salesforce id converter. Credits: https://github.com/heroku/salesforce_id_formatter
+
+module SalesforceIdFormatter
+  extend self
+
+  InvalidId = Class.new(StandardError)
+
+  def to_18(id)
+    raise InvalidId unless valid_id?(id)
+
+    id.size == 15 ? convert_15_to_18(id) : id
+  end
+
+  def to_15(id)
+    raise InvalidId unless valid_id?(id)
+
+    id.size == 18 ? convert_18_to_15(id) : id
+  end
+
+  def valid_id?(id)
+    [15, 18].include?(id.size) && id.match(/[^a-zA-Z0-9]/).nil?
+  end
+
+  private
+
+  def sfdc_base32_to_decimal(char)
+    sfdc_base32[char]
+  end
+
+  def decimal_to_sfdc_base32(dec)
+    Array(sfdc_base32.rassoc(dec)).first
+  end
+
+  # sfdc_base32 because base32 isn't a standard
+  # and this is salesforce's interpretation of it.
+  def sfdc_base32
+    @@b32 ||= begin
+      hash = {}
+      ('A'..'Z').each_with_index {|letter, idx| hash[letter] = idx }
+      ('0'..'5').each_with_index {|digit, idx|  hash[digit]  = idx + 26 }
+      hash
+    end
+  end
+
+  def is_upper?(char)
+    !(char =~ /[A-Z]/).nil?
+  end
+
+  # Algorithm http://salesforce.stackexchange.com/questions/1653/what-are-salesforce-ids-composed-of
+  def convert_15_to_18(str)
+    bits = str.split('').map{ |char| is_upper?(char) ? '1' : '0' }
+    checkdigits = [
+      bits[0..4].join.reverse.to_i(2),
+      bits[5..9].join.reverse.to_i(2),
+      bits[10..14].join.reverse.to_i(2)
+    ]
+
+    checkdigits = checkdigits.map {|d| decimal_to_sfdc_base32(d) }.join
+    str + checkdigits
+  end
+
+  def convert_18_to_15(str)
+    # Assume a default of lower-case for each char
+    base = str[0..14].downcase.split('')
+
+    # Convert the last 3 chars to their decimal value
+    dec = str[-3..-1].upcase.split('').collect { |char| sfdc_base32_to_decimal(char) }
+
+    # Convert the decimal values to their binary value, MSB in the on the 'right' of the string
+    bits = dec.map { |d| format('%05b', d.to_i).reverse.split('') }.flatten
+
+    # Finally, upper-case everything with a '1' in the binary string.
+    base.zip(bits).map {|char,bit| bit == '1' ? char.upcase : char }.join
+  end
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

If the Salesforce Contact ID parameter in the signup link is either 18-characters or 15-characters AND the user already created an account, redirect user to the “YOU'VE ALREADY SIGNED UP!” page

### Motivation and Context

We have a “YOU'VE ALREADY SIGNED UP!” page but it only works when the id matches that in platform. While majority of the IDs are 18-characters in platform (which should be what we get from the API), there’s currently 744 platform users saved with 15-character SFID, which majority, if not all, appear to be coming from the summer/fall 2020. Still investigating why.

When a  signup link with the opposing id (i.e., we have 18-chars saved on platform but the person is using a link with 15) is used by a program participant, it raises “Email looks like you've already signed up. Please log-in instead.”…and there’s no link to login instead, making it confusing for an end user.

### Test Plan / Screenshots (if appropriate):

TBD

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask around. -->

- [ ] My code follows the code style of this project.
- [ ] I have added neccessary labels
- [ ] My PR title follows the convention in the guide
- [ ] I have assigned myself to the PR
- [ ] I have requested reviews from team members
- [ ] I have created a task for reviewers on PM tool
- [ ] All new and existing tests passed.
