### PR TITLE
Exclude font files from being authenticated for Rise360 packages.

### DIFF
--- a/lib/lti_rise360_proxy.rb
+++ b/lib/lti_rise360_proxy.rb
@@ -36,7 +36,7 @@ class LtiRise360Proxy < Rack::Proxy
       path = $1 # from regex match above
       uri = URI(Rise360Util.presigned_url(path))
 
-      env["HTTP_HOST"] = uri.host           # e.g. some-bucket.s3.amazonaws.com
+      env['HTTP_HOST'] = uri.host           # e.g. some-bucket.s3.amazonaws.com
       env['PATH_INFO'] = uri.path           # The path matched in the regex above
       env['QUERY_STRING'] = uri.query       # The AWS query params signing it
 
@@ -54,6 +54,10 @@ private
   # the normal Rails controller routing, so we have to handle this
   # ourselves
   def authenticate(request)
+    # Exclude fonts from authentication. They are linked into CSS stylesheets and the
+    # state param is not in the referer when loaded. E.g. let icomoon.ttf and icomoon.woff load
+    return true if request.env['PATH_INFO'] =~ /\/lib\/fonts/
+
     warden = request.env['warden']
     return false unless warden
     return true if warden.authenticated? # short circuit if already authenticated using session

--- a/spec/lib/lti_rise360_proxy_spec.rb
+++ b/spec/lib/lti_rise360_proxy_spec.rb
@@ -99,6 +99,14 @@ RSpec.describe LtiRise360Proxy do
       it 'returns a 401 unauthorized' do
         expect(last_response.status).to eq(401)
       end
+
+      context 'getting a font file' do
+        let(:aws_s3_file_path) { '/lessons/ytec17h3ckbr92vcf7nklxmat4tc/lib/fonts/icomoon.woff' }
+        it 'allows the request' do
+          expect(warden).not_to have_received(:authenticated?)
+          expect(WebMock).to have_requested(:get, proxied_full_url).once
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Description
Followup to this task: https://app.asana.com/0/1174274412967132/1199668138554725

The fonts are linked in from a Rise360 CSS file which is the Referer.
Since we use the state param in the Referer to authenticate, the fonts
fail to load with a 401. Its fine to serve unauthenticated font files,
so just exclude them.

### Test Plan
Load a Rise360 Module and notice the following errors in the browser console:
![image](https://user-images.githubusercontent.com/5596986/111837296-11e82880-88ce-11eb-9b9f-dc79bba5bd8f.png)

After this change, the error goes away and those fonts load.

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open ticket or issue, please provide the link here. -->

### Screenshots (if appropriate):
<!-- Feel free to remove this section if it is not needed

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask around. -->

- [ ] My code follows the code style of this project.
- [ ] I have added neccessary labels
- [ ] My PR title follows the convention in the guide
- [ ] I have assigned myself to the PR
- [ ] I have requested reviews from team members
- [ ] I have created a task for reviewers on PM tool
- [ ] All new and existing tests passed.
